### PR TITLE
詳細な画面を追加した

### DIFF
--- a/lib/detail_page.dart
+++ b/lib/detail_page.dart
@@ -6,55 +6,82 @@ class DetailPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<CounterModel>(
       create: (_) => CounterModel(),
-        child:Scaffold(
-          appBar: AppBar(
-              title: Text('Code Scrolling'),
-          ),
-          body: Consumer<CounterModel>(builder: (_, model, __) {
-            return Center(
-              child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                  IconButton(
-                    icon: Icon(Icons.remove),
-                    tooltip: 'Decrement',
-                    onPressed: model.decrement
-                  ),
-                  Column(
+        child:Consumer<CounterModel>(builder: (_, model, __) {
+          return Scaffold(
+              appBar: AppBar(
+                title: Text('Code Scrolling'),
+              ),
+              body:
+              Center(
+                child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                    Text(
-                    'BPM:',
-                    ),
-                    CounterText(),
+                    children: [
+                      IconButton(
+                          icon: Icon(Icons.remove),
+                          tooltip: 'Decrement',
+                          onPressed: model.decrement
+                      ),
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          Text(
+                            'BPM:',
+                          ),
+                          CounterText(),
+                        ],
+                      ),
+                      IconButton(
+                          icon: Icon(Icons.add),
+                          tooltip: 'Increment',
+                          onPressed: model.increment
+                      ),
                     ],
                   ),
-                  IconButton(
-                    icon: Icon(Icons.add),
-                    tooltip: 'Increment',
-                    onPressed: model.increment
-                  ),
-                  ],
-            ),
-          );
-          }),
-        bottomNavigationBar: BottomNavigationBar(
-          items: const [
-            BottomNavigationBarItem(
-            icon: Icon(Icons.music_note),
-            label: "BPM",
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.play_arrow),
-              label: "PLAY"
-            ),
-            BottomNavigationBarItem(
-                icon: Icon(Icons.stop),
-                label:"STOP"
-            ),
-        ],
-        ),
-    ),
+
+                ),
+              persistentFooterButtons: [
+                Container(
+                  width: MediaQuery.of(context).size.width,
+                  height:60,
+                  child:Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                    children:[
+                      Expanded(
+                        child: TextButton(
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text("BPM:"),
+                                CounterText(),
+                              ],
+                            ),
+                              onPressed: () {
+                                //
+                              },
+                            ),
+                      ),
+                      Expanded(
+                        child: IconButton(
+                            icon: Icon(Icons.play_arrow),
+                          iconSize: 36,
+                            onPressed: (){
+                              //
+                            },
+                        ),
+                      ),
+                      Expanded(
+                        child: IconButton(
+                            icon: Icon(Icons.stop),
+                          iconSize: 36,
+                            onPressed: (){
+                              //
+                            },
+                        ),
+                      ),
+                  ]))],
+
+              );
+        }),
     );
   }
 }
@@ -64,7 +91,7 @@ class CounterText extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       Provider.of<CounterModel>(context).count.toString(),
-      style: Theme.of(context).textTheme.headline4,
+      style: TextStyle(fontSize: 20),
     );
   }
 }

--- a/lib/detail_page.dart
+++ b/lib/detail_page.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class DetailPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<CounterModel>(
+      create: (_) => CounterModel(),
+        child:Scaffold(
+          appBar: AppBar(
+              title: Text('Code Scrolling'),
+          ),
+          body: Consumer<CounterModel>(builder: (_, model, __) {
+            return Center(
+              child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                  IconButton(
+                    icon: Icon(Icons.remove),
+                    tooltip: 'Decrement',
+                    onPressed: model.decrement
+                  ),
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                    Text(
+                    'BPM:',
+                    ),
+                    CounterText(),
+                    ],
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.add),
+                    tooltip: 'Increment',
+                    onPressed: model.increment
+                  ),
+                  ],
+            ),
+          );
+          }),
+        bottomNavigationBar: BottomNavigationBar(
+          items: const [
+            BottomNavigationBarItem(
+            icon: Icon(Icons.music_note),
+            label: "BPM",
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.play_arrow),
+              label: "PLAY"
+            ),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.stop),
+                label:"STOP"
+            ),
+        ],
+        ),
+    ),
+    );
+  }
+}
+
+class CounterText extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      Provider.of<CounterModel>(context).count.toString(),
+      style: Theme.of(context).textTheme.headline4,
+    );
+  }
+}
+
+class CounterModel extends ChangeNotifier {
+  int count = 60;
+
+  void increment() {
+    count++;
+    notifyListeners();
+  }
+  void decrement() {
+    count--;
+    notifyListeners();
+  }
+}

--- a/lib/detail_page.dart
+++ b/lib/detail_page.dart
@@ -56,7 +56,7 @@ class DetailPage extends StatelessWidget {
                               ],
                             ),
                               onPressed: () {
-                                //
+                                print("Pressed: BPM");
                               },
                             ),
                       ),
@@ -65,7 +65,7 @@ class DetailPage extends StatelessWidget {
                             icon: Icon(Icons.play_arrow),
                           iconSize: 36,
                             onPressed: (){
-                              //
+                              print("Pressed: Play");
                             },
                         ),
                       ),
@@ -74,7 +74,7 @@ class DetailPage extends StatelessWidget {
                             icon: Icon(Icons.stop),
                           iconSize: 36,
                             onPressed: (){
-                              //
+                              print("Pressed: Stop");
                             },
                         ),
                       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,57 +1,55 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:my_app/detail_page.dart';
 
 void main() => runApp(MyApp());
-
-class CounterModel extends ChangeNotifier {
-  int count = 0;
-
-  void increment() {
-    count++;
-    notifyListeners();
-  }
-}
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: ChangeNotifierProvider<CounterModel>(
-        create: (_) => CounterModel(),
-        child: Scaffold(
-          appBar: AppBar(title: Text('Flutter Demo Home Page')),
+      title: 'Code Scrolling',
+      theme: ThemeData(primarySwatch: Colors.blueGrey),
+      home: MyHomePage(),
+    );
+  }
+}
+class MyHomePage extends StatelessWidget{
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+          appBar: AppBar(
+              centerTitle: true,
+              title: Text('main menu'),
+              actions: [
+                IconButton(
+                  icon: Icon(Icons.add),
+                  onPressed: (){
+                    //addボタンを押したら反応
+                  }
+                ),
+                IconButton(
+                  icon: Icon(Icons.share),
+                  onPressed: (){
+                    //shareボタンを押したら反応
+                  }
+                ),
+              ],
+          ),
           body: Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                Text(
-                  'You have pushed the button this many times:',
-                ),
-                CounterText(),
+                TextButton(onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (context) {
+                      return DetailPage();
+                    }),
+                  );
+                },
+                    child: Text('次のページへ')),
               ],
             ),
           ),
-          floatingActionButton: Consumer<CounterModel>(builder: (_, model, __) {
-            return FloatingActionButton(
-              onPressed: model.increment,
-              tooltip: 'Increment',
-              child: Icon(Icons.add),
-            );
-          }), // This trailing comma makes auto-formatting nicer for build methods.
-        ),
-      ),
-    );
-  }
-}
-
-class CounterText extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      Provider.of<CounterModel>(context).count.toString(),
-      style: Theme.of(context).textTheme.headline4,
-    );
+          );
   }
 }


### PR DESCRIPTION

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-05-03 at 15 26 57](https://user-images.githubusercontent.com/81696417/116848219-1458d480-ac27-11eb-908f-2ae8a2d932e6.png)
フッターを追加した（onPressedは何も書いてません）
曲など一覧できるメインページと、各詳細ページあるといいなと思い画面遷移できるようにした