### PR TITLE
曲を追加するときにバリデーションとダイアログを追加

### DIFF
--- a/lib/pages/create_song.dart
+++ b/lib/pages/create_song.dart
@@ -53,20 +53,40 @@ class _CreateSongFormState extends State<CreateSongForm> {
 
   void createButtonClicked() {
     // TODO バリデーションが満たされてなかったwarning いけてたら確認ダイアログ
-    showDialog(
-        context: context,
-        builder: (_) => new CupertinoAlertDialog(
-              title: new Text("Cupertino Dialog"),
-              content: new Text("Hey! I'm Coflutter!"),
-              actions: <Widget>[
-                FlatButton(
-                  child: Text('Close me!'),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                )
-              ],
-            ));
+    if (_title == "") {
+      showDialog(
+          context: context,
+          builder: (_) => new CupertinoAlertDialog(
+                title: new Text("エラー"),
+                content: new Text("タイトルを入力してください"),
+                actions: <Widget>[
+                  TextButton(
+                    child: Text('OK'),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  )
+                ],
+              ));
+    } else {
+      showDialog(
+          context: context,
+          builder: (_) => new CupertinoAlertDialog(
+                title: new Text("確認"),
+                content: new Text(
+                    "以下の曲を作成します\nタイトル: ${_title.toString()}\nBPM: ${_bpm.toString()}"),
+                actions: <Widget>[
+                  TextButton(
+                    child: Text("Cancel"),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                  TextButton(
+                    child: Text("OK"),
+                    onPressed: () async => createSong(),
+                  ),
+                ],
+              ));
+    }
   }
 
   void createSong() async {
@@ -79,7 +99,8 @@ class _CreateSongFormState extends State<CreateSongForm> {
       "createdAt": DateTime.now(),
       "updatedAt": DateTime.now(),
     });
-    Navigator.of(context).pop(
+    // 　ここはいずれ詳細ページにそのまま飛ばしたい
+    Navigator.of(context).push(
       MaterialPageRoute(builder: (context) {
         return SongsList();
       }),

--- a/lib/pages/create_song.dart
+++ b/lib/pages/create_song.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_udid/flutter_udid.dart';
@@ -50,7 +51,25 @@ class _CreateSongFormState extends State<CreateSongForm> {
     });
   }
 
-  void submitSong() async {
+  void createButtonClicked() {
+    // TODO バリデーションが満たされてなかったwarning いけてたら確認ダイアログ
+    showDialog(
+        context: context,
+        builder: (_) => new CupertinoAlertDialog(
+              title: new Text("Cupertino Dialog"),
+              content: new Text("Hey! I'm Coflutter!"),
+              actions: <Widget>[
+                FlatButton(
+                  child: Text('Close me!'),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                )
+              ],
+            ));
+  }
+
+  void createSong() async {
     String udid = await FlutterUdid.udid;
 
     FirebaseFirestore.instance.collection("Songs").add({
@@ -106,7 +125,7 @@ class _CreateSongFormState extends State<CreateSongForm> {
             color: Colors.orange,
             textColor: Colors.white,
             onPressed: () {
-              submitSong();
+              createButtonClicked();
             },
           ),
         ],

--- a/lib/pages/create_song.dart
+++ b/lib/pages/create_song.dart
@@ -56,9 +56,9 @@ class _CreateSongFormState extends State<CreateSongForm> {
     if (_title == "") {
       showDialog(
           context: context,
-          builder: (_) => new CupertinoAlertDialog(
-                title: new Text("エラー"),
-                content: new Text("タイトルを入力してください"),
+          builder: (_) => CupertinoAlertDialog(
+                title: Text("エラー"),
+                content: Text("タイトルを入力してください"),
                 actions: <Widget>[
                   TextButton(
                     child: Text('OK'),
@@ -71,9 +71,9 @@ class _CreateSongFormState extends State<CreateSongForm> {
     } else {
       showDialog(
           context: context,
-          builder: (_) => new CupertinoAlertDialog(
-                title: new Text("確認"),
-                content: new Text(
+          builder: (_) => CupertinoAlertDialog(
+                title: Text("確認"),
+                content: Text(
                     "以下の曲を作成します\nタイトル: ${_title.toString()}\nBPM: ${_bpm.toString()}"),
                 actions: <Widget>[
                   TextButton(


### PR DESCRIPTION
<img width="373" alt="スクリーンショット 2021-08-03 13 47 05" src="https://user-images.githubusercontent.com/32502331/127960579-e6740859-6535-4715-9b08-6427032ecbb7.png">
<img width="364" alt="スクリーンショット 2021-08-03 13 46 56" src="https://user-images.githubusercontent.com/32502331/127960586-7c722958-bec3-44cf-b2a3-49df1d459cbb.png">


ダイアログから画面遷移するときにpushを使っているのを今後なんとかしたい
最終的にはそのまま詳細ページに飛ばす予定