### PR TITLE
Drawerに項目を追加した

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -380,7 +380,7 @@ SPEC CHECKSUMS:
   FirebaseCore: a6dba751680d7033b9d3831e1cfc95ead0605118
   FirebaseCoreDiagnostics: cad03be1904b975f845e632f2720c3337da27faf
   FirebaseFirestore: f4f42828c6d82f6945575611c23dd343e0e7d0aa
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   flutter_udid: 0848809dbed4c055175747ae6a45a8b4f6771e1c
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c

--- a/lib/pages/create_song.dart
+++ b/lib/pages/create_song.dart
@@ -4,8 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_udid/flutter_udid.dart';
 
-import 'songs_list.dart';
-
 class CreateSong extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -101,11 +99,7 @@ class _CreateSongFormState extends State<CreateSongForm> {
       "updatedAt": DateTime.now(),
     });
     // 　ここはいずれ詳細ページにそのまま飛ばしたい
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) {
-        return SongsList();
-      }),
-    );
+    Navigator.of(context).popUntil((route) => route.isFirst);
   }
 
   Widget build(BuildContext context) {

--- a/lib/pages/detail_page/detail_page.dart
+++ b/lib/pages/detail_page/detail_page.dart
@@ -156,7 +156,7 @@ class DetailPage extends StatelessWidget {
                           })))),
         ),
         bottomNavigationBar: detailBottomBar(context, model),
-        endDrawer: settingsDrawer(context, model, bpm, title),
+        endDrawer: settingsDrawer(context, model, bpm, title, docId),
       );
     });
   }

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -6,6 +6,7 @@ import '../../models/metronome_model.dart';
 Drawer settingsDrawer(
     BuildContext context, MetronomeModel model, int bpm, String title) {
   final double titleTextFont = 16;
+  final insertPadding = Padding(padding: EdgeInsets.all(10));
 
   return Drawer(
     child: Container(
@@ -35,7 +36,7 @@ Drawer settingsDrawer(
               //TODO ボタンを押したら情報変更画面
             },
           ),
-          Padding(padding: EdgeInsets.all(10)),
+          insertPadding,
           Text(
             "メトロノームのサウンド",
             style: TextStyle(
@@ -51,6 +52,32 @@ Drawer settingsDrawer(
                 print("Metronome Sound");
                 //TODO
               }),
+          insertPadding,
+          Text(
+            "カウントイン",
+            style: TextStyle(
+              fontSize: titleTextFont,
+              color: Colors.white,
+            ),
+          ),
+          ListTile(
+              tileColor: Theme.of(context).primaryColorDark,
+              title: Text("回数：" + model.countInTimes.toString(),
+                  style: TextStyle(color: Colors.white)),
+              onTap: () {
+                print("Count-in Times");
+                //TODO
+              }),
+          insertPadding,
+          ElevatedButton(
+            child: Text("曲を削除する", style: TextStyle(color: Colors.red)),
+            style: ElevatedButton.styleFrom(
+                primary: Theme.of(context).primaryColorLight),
+            onPressed: () {
+              //TODO
+              print("deleted");
+            },
+          ),
         ],
       ),
     ),

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -87,13 +87,13 @@ Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
                           ),
                           TextButton(
                               child: Text("OK"),
-                              onPressed: () {
+                              onPressed: () async {
+                                await Navigator.popUntil(context,
+                                    (Route<dynamic> route) => route.isFirst);
                                 FirebaseFirestore.instance
                                     .collection('Songs')
                                     .doc(docId)
                                     .delete();
-                                Navigator.popUntil(context,
-                                    (Route<dynamic> route) => route.isFirst);
                               }),
                         ],
                       ));

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -87,9 +87,10 @@ Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
                           ),
                           TextButton(
                               child: Text("OK"),
-                              onPressed: () {
+                              onPressed: () async {
                                 Navigator.of(context)
                                     .popUntil((route) => route.isFirst);
+                                await Future.delayed(Duration(seconds: 1));
                                 FirebaseFirestore.instance
                                     .collection('Songs')
                                     .doc(docId)

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -87,13 +87,14 @@ Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
                           ),
                           TextButton(
                               child: Text("OK"),
-                              onPressed: () async {
-                                await Navigator.popUntil(context,
-                                    (Route<dynamic> route) => route.isFirst);
+                              onPressed: () {
+                                Navigator.of(context)
+                                    .popUntil((route) => route.isFirst);
                                 FirebaseFirestore.instance
                                     .collection('Songs')
                                     .doc(docId)
                                     .delete();
+                                //TODO FirstPageへの値渡しで画面遷移後に削除
                               }),
                         ],
                       ));

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -1,10 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../../models/metronome_model.dart';
 
-Drawer settingsDrawer(
-    BuildContext context, MetronomeModel model, int bpm, String title) {
+Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
+    String title, String docId) {
   final double titleTextFont = 16;
   final insertPadding = Padding(padding: EdgeInsets.all(10));
 
@@ -74,8 +75,28 @@ Drawer settingsDrawer(
             style: ElevatedButton.styleFrom(
                 primary: Theme.of(context).primaryColorLight),
             onPressed: () {
-              //TODO
-              print("deleted");
+              showDialog(
+                  context: context,
+                  builder: (_) => CupertinoAlertDialog(
+                        title: Text("確認"),
+                        content: Text(title + "を削除してもよいですか？"),
+                        actions: <Widget>[
+                          TextButton(
+                            child: Text("キャンセル"),
+                            onPressed: () => Navigator.pop(context),
+                          ),
+                          TextButton(
+                              child: Text("OK"),
+                              onPressed: () {
+                                FirebaseFirestore.instance
+                                    .collection('Songs')
+                                    .doc(docId)
+                                    .delete();
+                                Navigator.popUntil(context,
+                                    (Route<dynamic> route) => route.isFirst);
+                              }),
+                        ],
+                      ));
             },
           ),
         ],


### PR DESCRIPTION
【やったこと】
Drawerに削除ボタン追加した（曲一覧と詳細画面どちらからでも削除できた方が良さそう）
CreateSongで曲作った後一旦Popuntilでトップまで戻した（今までPushだったから）。

【問題点】
詳細画面で削除を実行するとその瞬間にデータがなくなって赤画面になる
→非同期処理とかも試したけど画面遷移のわずかな間で赤画面が見えちゃう
→FirstPageへ遷移した際にDeleteThisみたいな引数渡して、遷移が完全に完了してから削除とかしたい

https://user-images.githubusercontent.com/81696417/128594627-80a9a731-6610-4bc2-bd43-a1be27819f10.mov

