### PR TITLE
Consumerの範囲を狭める

### DIFF
--- a/lib/pages/detail_page/countin_dialog.dart
+++ b/lib/pages/detail_page/countin_dialog.dart
@@ -7,31 +7,29 @@ import 'metronome_container.dart';
 class CountInDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Consumer<MetronomeModel>(builder: (_, model, __) {
-      return Dialog(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(16))),
-        child: SizedBox(
-          width: MediaQuery.of(context).size.width / 2,
-          height: 100,
-          child: Center(
-            child: ListView(
-              shrinkWrap: true,
-              padding: EdgeInsets.all(10),
-              scrollDirection: Axis.horizontal,
-              children: List.generate(model.countInTimes, (cNum) => cNum)
-                  .map((cNum) => Container(
-                        padding: EdgeInsets.all(5),
-                        child: MetronomeContainerWidget(
-                            contentState: cNum, contentNum: model.countInTimes),
-                      ))
-                  .toList(),
-            ),
-          ),
-        ),
-      );
-    });
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(16))),
+      child: SizedBox(
+        width: MediaQuery.of(context).size.width / 2,
+        height: 100,
+        child: Center(child: Consumer<MetronomeModel>(builder: (_, model, __) {
+          return ListView(
+            shrinkWrap: true,
+            padding: EdgeInsets.all(10),
+            scrollDirection: Axis.horizontal,
+            children: List.generate(model.countInTimes, (cNum) => cNum)
+                .map((cNum) => Container(
+                      padding: EdgeInsets.all(5),
+                      child: MetronomeContainerWidget(
+                          contentState: cNum, contentNum: model.countInTimes),
+                    ))
+                .toList(),
+          );
+        })),
+      ),
+    );
   }
 }

--- a/lib/pages/detail_page/detail_bottom_bar.dart
+++ b/lib/pages/detail_page/detail_bottom_bar.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../models/metronome_model.dart';
 import 'bpm_setting.dart';
 import 'countin_dialog.dart';
 import 'volume_setting.dart';
 
-Container detailBottomBar(BuildContext context, MetronomeModel model) {
+Container detailBottomBar(BuildContext context) {
   final double bottomIconSIze = 36;
   final Color textColor = Colors.white;
 
@@ -20,54 +21,61 @@ Container detailBottomBar(BuildContext context, MetronomeModel model) {
           flex: 1,
           child: SizedBox(
             height: 60,
-            child: TextButton(
-              style: TextButton.styleFrom(
-                backgroundColor: model.metronomeContainerColor,
-                shape: CircleBorder(),
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text("BPM", style: TextStyle(color: textColor)),
-                  Text(
-                    model.tempoCount.toString(),
-                    style: TextStyle(fontSize: 20, color: textColor),
-                  ),
-                ],
-              ),
-              onPressed: () {
-                print("Pressed: BPM");
-                showModalBottomSheet<void>(
-                  backgroundColor: Theme.of(context).primaryColor,
-                  shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.all(Radius.circular(32.0))),
-                  context: context,
-                  builder: (context) => BpmSetting(),
-                ).then((_) => model.resetBpmTapCount());
-              },
-            ),
+            child: Consumer<MetronomeModel>(builder: (_, model, __) {
+              return TextButton(
+                style: TextButton.styleFrom(
+                  backgroundColor: model.metronomeContainerColor,
+                  shape: CircleBorder(),
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text("BPM", style: TextStyle(color: textColor)),
+                    Text(
+                      model.tempoCount.toString(),
+                      style: TextStyle(fontSize: 20, color: textColor),
+                    ),
+                  ],
+                ),
+                onPressed: () {
+                  print("Pressed: BPM");
+                  showModalBottomSheet<void>(
+                    backgroundColor: Theme.of(context).primaryColor,
+                    shape: const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.all(Radius.circular(32.0))),
+                    context: context,
+                    builder: (context) => BpmSetting(),
+                  ).then((_) => model.resetBpmTapCount());
+                },
+              );
+            }),
           ),
         ),
         Expanded(
           flex: 1,
-          child: !model.isPlaying
+          child: !Provider.of<MetronomeModel>(context, listen: false).isPlaying
               ? IconButton(
                   color: textColor,
                   icon: Icon(Icons.play_arrow_rounded),
                   iconSize: bottomIconSIze,
                   onPressed: () async {
-                    model.switchPlayStatus();
-                    model.metronomeLoad();
+                    Provider.of<MetronomeModel>(context, listen: false)
+                        .switchPlayStatus();
+                    Provider.of<MetronomeModel>(context, listen: false)
+                        .metronomeLoad();
                     print("Pressed: Play");
-                    if (model.metronomeContainerStatus <
-                        model.countInTimes - 1) {
+                    if (Provider.of<MetronomeModel>(context, listen: false)
+                            .metronomeContainerStatus <
+                        Provider.of<MetronomeModel>(context, listen: false)
+                                .countInTimes -
+                            1) {
                       showDialog(
                           barrierDismissible: false,
                           context: context,
                           builder: (BuildContext context) {
                             return CountInDialog();
                           });
-                      await model
+                      await Provider.of<MetronomeModel>(context, listen: false)
                           .waitUntilCountInEnds()
                           .then((_) => Navigator.of(context).pop());
                     }
@@ -78,8 +86,10 @@ Container detailBottomBar(BuildContext context, MetronomeModel model) {
                   icon: Icon(Icons.pause_rounded),
                   iconSize: bottomIconSIze,
                   onPressed: () {
-                    model.metronomeClear();
-                    model.switchPlayStatus();
+                    Provider.of<MetronomeModel>(context, listen: false)
+                        .metronomeClear();
+                    Provider.of<MetronomeModel>(context, listen: false)
+                        .switchPlayStatus();
                     print("Pressed: Pause");
                   },
                 ),
@@ -91,7 +101,7 @@ Container detailBottomBar(BuildContext context, MetronomeModel model) {
             icon: Icon(Icons.stop_rounded),
             iconSize: bottomIconSIze,
             onPressed: () {
-              model.forceStop();
+              Provider.of<MetronomeModel>(context, listen: false).forceStop();
               print("Pressed: Stop");
             },
           ),

--- a/lib/pages/detail_page/detail_bottom_bar.dart
+++ b/lib/pages/detail_page/detail_bottom_bar.dart
@@ -51,49 +51,52 @@ Container detailBottomBar(BuildContext context) {
             }),
           ),
         ),
-        Expanded(
-          flex: 1,
-          child: !Provider.of<MetronomeModel>(context, listen: false).isPlaying
-              ? IconButton(
-                  color: textColor,
-                  icon: Icon(Icons.play_arrow_rounded),
-                  iconSize: bottomIconSIze,
-                  onPressed: () async {
-                    Provider.of<MetronomeModel>(context, listen: false)
-                        .switchPlayStatus();
-                    Provider.of<MetronomeModel>(context, listen: false)
-                        .metronomeLoad();
-                    print("Pressed: Play");
-                    if (Provider.of<MetronomeModel>(context, listen: false)
-                            .metronomeContainerStatus <
-                        Provider.of<MetronomeModel>(context, listen: false)
-                                .countInTimes -
-                            1) {
-                      showDialog(
-                          barrierDismissible: false,
-                          context: context,
-                          builder: (BuildContext context) {
-                            return CountInDialog();
-                          });
-                      await Provider.of<MetronomeModel>(context, listen: false)
-                          .waitUntilCountInEnds()
-                          .then((_) => Navigator.of(context).pop());
-                    }
-                  },
-                )
-              : IconButton(
-                  color: textColor,
-                  icon: Icon(Icons.pause_rounded),
-                  iconSize: bottomIconSIze,
-                  onPressed: () {
-                    Provider.of<MetronomeModel>(context, listen: false)
-                        .metronomeClear();
-                    Provider.of<MetronomeModel>(context, listen: false)
-                        .switchPlayStatus();
-                    print("Pressed: Pause");
-                  },
-                ),
-        ),
+        Consumer<MetronomeModel>(builder: (_, model, __) {
+          return Expanded(
+            flex: 1,
+            child: !model.isPlaying
+                ? IconButton(
+                    color: textColor,
+                    icon: Icon(Icons.play_arrow_rounded),
+                    iconSize: bottomIconSIze,
+                    onPressed: () async {
+                      Provider.of<MetronomeModel>(context, listen: false)
+                          .switchPlayStatus();
+                      Provider.of<MetronomeModel>(context, listen: false)
+                          .metronomeLoad();
+                      print("Pressed: Play");
+                      if (Provider.of<MetronomeModel>(context, listen: false)
+                              .metronomeContainerStatus <
+                          Provider.of<MetronomeModel>(context, listen: false)
+                                  .countInTimes -
+                              1) {
+                        showDialog(
+                            barrierDismissible: false,
+                            context: context,
+                            builder: (BuildContext context) {
+                              return CountInDialog();
+                            });
+                        await Provider.of<MetronomeModel>(context,
+                                listen: false)
+                            .waitUntilCountInEnds()
+                            .then((_) => Navigator.of(context).pop());
+                      }
+                    },
+                  )
+                : IconButton(
+                    color: textColor,
+                    icon: Icon(Icons.pause_rounded),
+                    iconSize: bottomIconSIze,
+                    onPressed: () {
+                      Provider.of<MetronomeModel>(context, listen: false)
+                          .metronomeClear();
+                      Provider.of<MetronomeModel>(context, listen: false)
+                          .switchPlayStatus();
+                      print("Pressed: Pause");
+                    },
+                  ),
+          );
+        }),
         Expanded(
           flex: 1,
           child: IconButton(

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -103,33 +103,32 @@ class DetailEditPage extends StatelessWidget {
       );
     }
 
-    return Consumer<EditingSongModel>(builder: (_, model, __) {
-      return Scaffold(
-          resizeToAvoidBottomInset: false,
-          appBar: AppBar(
-            centerTitle: true,
-            leading: IconButton(
-                icon: Icon(Icons.arrow_back_ios),
-                onPressed: () {
-                  model.closeKeyboard();
-                  Navigator.of(context).pop();
-                }),
-            title: Text("編集ページ"),
-            actions: <Widget>[],
-          ),
-          body: Builder(
-            builder: (context) => Container(
-                child: Scrollbar(
-                    isAlwaysShown: true,
-                    thickness: 8.0,
-                    hoverThickness: 12.0,
-                    child: Padding(
-                      padding: EdgeInsets.only(
-                          bottom: Provider.of<EditingSongModel>(context)
-                              .keyboardBottomSpace),
-                      child: SingleChildScrollView(
-                        child: Center(
-                            child: Column(
+    return Scaffold(
+        resizeToAvoidBottomInset: false,
+        appBar: AppBar(
+          centerTitle: true,
+          leading: IconButton(
+              icon: Icon(Icons.arrow_back_ios),
+              onPressed: () {
+                Provider.of<EditingSongModel>(context, listen: false)
+                    .closeKeyboard();
+                Navigator.of(context).pop();
+              }),
+          title: Text("編集ページ"),
+          actions: <Widget>[],
+        ),
+        body: Builder(
+          builder: (context) => Container(
+              child: Scrollbar(
+                  isAlwaysShown: true,
+                  thickness: 8.0,
+                  hoverThickness: 12.0,
+                  child: Padding(
+                    padding: bottomPadding(context),
+                    child: SingleChildScrollView(
+                      child: Center(child:
+                          Consumer<EditingSongModel>(builder: (_, model, __) {
+                        return Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
                             Text("コードの編集"),
@@ -186,11 +185,16 @@ class DetailEditPage extends StatelessWidget {
                               },
                             ),
                           ],
-                        )),
-                      ),
-                    ))),
-            //bottomSheet: CustomKeyboard(),
-          ));
-    });
+                        );
+                      })),
+                    ),
+                  ))),
+          //bottomSheet: CustomKeyboard(),
+        ));
   }
+}
+
+EdgeInsets bottomPadding(context) {
+  return EdgeInsets.only(
+      bottom: Provider.of<EditingSongModel>(context).keyboardBottomSpace);
 }

--- a/lib/pages/detail_page/detail_page.dart
+++ b/lib/pages/detail_page/detail_page.dart
@@ -19,43 +19,41 @@ class DetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<MetronomeModel>(builder: (_, model, __) {
-      return Scaffold(
-        key: _scaffoldKey,
-        appBar: AppBar(
-          centerTitle: true,
-          leading: IconButton(
-              icon: Icon(Icons.arrow_back_ios),
+    return Scaffold(
+      key: _scaffoldKey,
+      appBar: AppBar(
+        centerTitle: true,
+        leading: IconButton(
+            icon: Icon(Icons.arrow_back_ios),
+            onPressed: () {
+              Navigator.of(context).pop();
+              Provider.of<MetronomeModel>(context, listen: false).forceStop();
+            }),
+        title: Text(title),
+        actions: <Widget>[
+          IconButton(
+              icon: Icon(Icons.settings),
               onPressed: () {
-                Navigator.of(context).pop();
-                model.forceStop();
+                _scaffoldKey.currentState.openEndDrawer();
               }),
-          title: Text(title),
-          actions: <Widget>[
-            IconButton(
-                icon: Icon(Icons.settings),
-                onPressed: () {
-                  _scaffoldKey.currentState.openEndDrawer();
-                }),
-          ],
-        ),
-        body: Container(
-            child: StreamBuilder(
-                stream: FirebaseFirestore.instance
-                    .collection('Songs')
-                    .doc(docId)
-                    .snapshots(),
-                builder: (context, AsyncSnapshot<DocumentSnapshot> snapshot) {
-                  if (!snapshot.hasData) {
-                    return Center(child: Text("Loading"));
-                  }
-                  var songDocument = snapshot.data;
-                  var codeList = songDocument["codeList"].cast<String>();
-                  return ScrollablePage(codeList, bpm, title, docId);
-                })),
-        bottomNavigationBar: detailBottomBar(context, model),
-        endDrawer: settingsDrawer(context, model, bpm, title, docId),
-      );
-    });
+        ],
+      ),
+      body: Container(
+          child: StreamBuilder(
+              stream: FirebaseFirestore.instance
+                  .collection('Songs')
+                  .doc(docId)
+                  .snapshots(),
+              builder: (context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+                if (!snapshot.hasData) {
+                  return Center(child: Text("Loading"));
+                }
+                var songDocument = snapshot.data;
+                var codeList = songDocument["codeList"].cast<String>();
+                return ScrollablePage(codeList, bpm, title, docId);
+              })),
+      bottomNavigationBar: detailBottomBar(context),
+      endDrawer: settingsDrawer(context, bpm, title, docId),
+    );
   }
 }

--- a/lib/pages/detail_page/metronome_container.dart
+++ b/lib/pages/detail_page/metronome_container.dart
@@ -37,12 +37,12 @@ class MetronomeContainerWidget extends StatelessWidget {
             width: 0.1,
           ),
           shape: BoxShape.circle,
-          color: metronomeContainerColor(context, contentNum, contentState)),
+          color: countInContainerColor(context, contentNum, contentState)),
     );
   }
 }
 
-Color metronomeContainerColor(context, contentNum, contentState) {
+Color countInContainerColor(context, contentNum, contentState) {
   if (!Provider.of<MetronomeModel>(context).isPlaying) {
     return Colors.white;
   } else if (Provider.of<MetronomeModel>(context).metronomeContainerStatus %

--- a/lib/pages/detail_page/metronome_container.dart
+++ b/lib/pages/detail_page/metronome_container.dart
@@ -6,18 +6,16 @@ import '../../models/metronome_model.dart';
 class MetronomeContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Consumer<MetronomeModel>(builder: (_, model, __) {
-      return Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          MetronomeContainerWidget(contentState: 0, contentNum: 2),
-          Padding(
-            padding: EdgeInsets.fromLTRB(0, 0, 5, 0),
-          ),
-          MetronomeContainerWidget(contentState: 1, contentNum: 2),
-        ],
-      );
-    });
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        MetronomeContainerWidget(contentState: 0, contentNum: 2),
+        Padding(
+          padding: EdgeInsets.fromLTRB(0, 0, 5, 0),
+        ),
+        MetronomeContainerWidget(contentState: 1, contentNum: 2),
+      ],
+    );
   }
 }
 
@@ -30,22 +28,28 @@ class MetronomeContainerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<MetronomeModel>(builder: (_, model, __) {
-      return Container(
-        width: 20,
-        height: 20,
-        decoration: BoxDecoration(
-            border: Border.all(
-              color: Colors.black,
-              width: 0.1,
-            ),
-            shape: BoxShape.circle,
-            color: !model.isPlaying
-                ? Colors.white
-                : (model.metronomeContainerStatus % contentNum == contentState
-                    ? Colors.orange
-                    : Colors.white)),
-      );
-    });
+    return Container(
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+          border: Border.all(
+            color: Colors.black,
+            width: 0.1,
+          ),
+          shape: BoxShape.circle,
+          color: metronomeContainerColor(context, contentNum, contentState)),
+    );
+  }
+}
+
+Color metronomeContainerColor(context, contentNum, contentState) {
+  if (!Provider.of<MetronomeModel>(context).isPlaying) {
+    return Colors.white;
+  } else if (Provider.of<MetronomeModel>(context).metronomeContainerStatus %
+          contentNum ==
+      contentState) {
+    return Colors.orange;
+  } else {
+    return Colors.white;
   }
 }

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -1,11 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../models/metronome_model.dart';
 
-Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
-    String title, String docId) {
+Drawer settingsDrawer(
+    BuildContext context, int bpm, String title, String docId) {
   final double titleTextFont = 16;
   final insertPadding = Padding(padding: EdgeInsets.all(10));
 
@@ -47,8 +48,10 @@ Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
           ),
           ListTile(
               tileColor: Theme.of(context).primaryColorDark,
-              title: Text(model.metronomeSound,
-                  style: TextStyle(color: Colors.white)),
+              title: Consumer<MetronomeModel>(builder: (_, model, __) {
+                return Text(model.metronomeSound,
+                    style: TextStyle(color: Colors.white));
+              }),
               onTap: () {
                 print("Metronome Sound");
                 //TODO
@@ -63,8 +66,10 @@ Drawer settingsDrawer(BuildContext context, MetronomeModel model, int bpm,
           ),
           ListTile(
               tileColor: Theme.of(context).primaryColorDark,
-              title: Text("回数：" + model.countInTimes.toString(),
-                  style: TextStyle(color: Colors.white)),
+              title: Consumer<MetronomeModel>(builder: (_, model, __) {
+                return Text("回数：" + model.countInTimes.toString(),
+                    style: TextStyle(color: Colors.white));
+              }),
               onTap: () {
                 print("Count-in Times");
                 //TODO


### PR DESCRIPTION
可能な限りConsumerのスコープを狭めること、またProvider.of<Model>.~~のlisten:true　を使うときはそのウィジェット全体がリビルドされてしまうらしいので別ウィジェットに書き換える必要がありそう

参考サイト
https://qiita.com/hohohoris/items/8aecf6a99b278d67d13b

あとはConsumer使う時に第３引数にChild指定できて、そこでもリビルドを最小限位できるらしい
https://blog.dalt.me/1903

ConsumerでEditing ModelとMetronomeModel同時に使うようなことがあった場合、Consumer2とかあってChangeNotifierを二つ引数指定できるらしい、しかもConsumer6まである