### PR TITLE
再生中の小節までスクロールする

### DIFF
--- a/lib/models/metronome_model.dart
+++ b/lib/models/metronome_model.dart
@@ -9,8 +9,13 @@ import 'package:quiver/async.dart';
 void audioPlayerHandler(AudioPlayerState value) => null;
 
 class MetronomeModel extends ChangeNotifier {
+  bool _isPlaying = false;
+  get isPlaying => _isPlaying;
+
   int _tempoCount;
   get tempoCount => _tempoCount;
+
+  Timer _tempoTapTimer;
 
   set tempoCount(int bpm) {
     if (bpm < 30)
@@ -20,113 +25,6 @@ class MetronomeModel extends ChangeNotifier {
     else
       _tempoCount = bpm;
   }
-
-  bool _isPlaying = false;
-  get isPlaying => _isPlaying;
-
-  DateTime _bpmTapStartTime;
-  int _bpmTapCount = 0;
-  var _bpmCalculateList = <int>[];
-  String _bpmTapText = "TAPで計測開始";
-
-  get bpmTapCount => _bpmTapCount;
-  get bpmTapText => _bpmTapText;
-
-  AudioPlayer _audioPlayer = AudioPlayer(mode: PlayerMode.LOW_LATENCY)
-    ..setReleaseMode(ReleaseMode.STOP);
-  AudioCache _metronomePlayer = AudioCache(
-      fixedPlayer: AudioPlayer(mode: PlayerMode.LOW_LATENCY)
-        ..setReleaseMode(ReleaseMode.STOP));
-  String _metronomeSound = "sounds/Metronome.mp3";
-  final List<String> _metronomeSoundsList = [
-    "sounds/Metronome.mp3",
-    "sounds/Click.mp3",
-    "sounds/WoodBlock.mp3",
-  ];
-  get metronomeSound => _metronomeSound;
-  get metronomeSoundsList => _metronomeSoundsList;
-
-  set metronomeSound(int selectedIndex) {
-    _metronomeSound = _metronomeSoundsList[selectedIndex];
-    notifyListeners();
-  }
-
-  Metronome _metronomeTimer;
-  StreamSubscription<DateTime> _metronomeSubscription;
-
-  List<int> _ticksPerRowList = [];
-  get ticksPerRowList => _ticksPerRowList;
-
-  set ticksPerRowList(List<String> fetchedRhythmList) {
-    _ticksPerRowList = [];
-    if (fetchedRhythmList == []) {
-      _ticksPerRowList = [];
-    } else {
-      for (int i = 0; i < fetchedRhythmList.length; i++) {
-        List<String> beatCountList = fetchedRhythmList[i].split('/');
-        if (beatCountList[1] == "4") {
-          _ticksPerRowList.add(int.parse(beatCountList[0]));
-        } else if (beatCountList[1] == "8") {
-          _ticksPerRowList.add(int.parse(beatCountList[0]) ~/ 2);
-        } else if (beatCountList[1] == "16") {
-          _ticksPerRowList.add(int.parse(beatCountList[0]) ~/ 4);
-        }
-      }
-    }
-  }
-
-  List<int> _maxTickList = [];
-
-  double _scrollRate = 0.0;
-  get scrollRate => _scrollRate;
-
-  ScrollController scrollController;
-
-  /// codeNumList : 一列あたりの小節数を受けてmetronomeContainerStatusの列ごとの最大数をリスト化
-  void setMaxTickList(int fetchedBarNum, [int listIndex]) {
-    if (fetchedBarNum == -1) {
-      //scrollablePage呼び出し時に初期化
-      _maxTickList = [];
-    } else {
-      if (listIndex == 0) {
-        _maxTickList.add(fetchedBarNum * _ticksPerRowList[listIndex]);
-      } else {
-        _maxTickList.add(_maxTickList[listIndex - 1] +
-            fetchedBarNum * _ticksPerRowList[listIndex]);
-      }
-    }
-  }
-
-  double deviceHeight = 0;
-  List<double> _textFormOffsetList = [];
-  get textFormOffsetList => _textFormOffsetList;
-
-  set textFormOffsetList(double dy) {
-    if (dy == -1) {
-      //scrollablePage呼び出し時に初期化
-      _textFormOffsetList = [];
-    } else {
-      _textFormOffsetList.add(dy);
-    }
-  }
-
-  Color _metronomeContainerColor;
-  get metronomeContainerColor => _metronomeContainerColor;
-
-  double _soundVolume = 1;
-  get soundVolume => _soundVolume;
-
-  ///初期値を-1にするとメトロノームが鳴る１回目に一番左(mod CountIn == 0になる)がフラッシュする
-  int _metronomeContainerStatus = -1;
-  get metronomeContainerStatus => _metronomeContainerStatus;
-
-  int _countInTimes = 4;
-  get countInTimes => _countInTimes;
-
-  bool _isCountInPlaying = false;
-  get isCountInPlaying => _isCountInPlaying;
-
-  Timer _tempoTapTimer;
 
   void tempoUp() {
     if (_tempoCount < 300) {
@@ -175,6 +73,13 @@ class MetronomeModel extends ChangeNotifier {
     }
   }
 
+  DateTime _bpmTapStartTime;
+  int _bpmTapCount = 0;
+  var _bpmCalculateList = <int>[];
+  String _bpmTapText = "TAPで計測開始";
+  get bpmTapCount => _bpmTapCount;
+  get bpmTapText => _bpmTapText;
+
   void bpmTapDetector() {
     const bpmMin = 30;
     const bpmMax = 300;
@@ -219,6 +124,45 @@ class MetronomeModel extends ChangeNotifier {
     _bpmTapText = "TAPで計測開始";
   }
 
+  AudioPlayer _audioPlayer = AudioPlayer(mode: PlayerMode.LOW_LATENCY)
+    ..setReleaseMode(ReleaseMode.STOP);
+  AudioCache _metronomePlayer = AudioCache(
+      fixedPlayer: AudioPlayer(mode: PlayerMode.LOW_LATENCY)
+        ..setReleaseMode(ReleaseMode.STOP));
+
+  String _metronomeSound = "sounds/Metronome.mp3";
+  get metronomeSound => _metronomeSound;
+  set metronomeSound(int selectedIndex) {
+    _metronomeSound = _metronomeSoundsList[selectedIndex];
+    notifyListeners();
+  }
+
+  final List<String> _metronomeSoundsList = [
+    "sounds/Metronome.mp3",
+    "sounds/Click.mp3",
+    "sounds/WoodBlock.mp3",
+  ];
+  get metronomeSoundsList => _metronomeSoundsList;
+
+  Metronome _metronomeTimer;
+  StreamSubscription<DateTime> _metronomeSubscription;
+
+  Color _metronomeContainerColor;
+  get metronomeContainerColor => _metronomeContainerColor;
+
+  double _soundVolume = 1;
+  get soundVolume => _soundVolume;
+
+  ///初期値を-1にするとメトロノームが鳴る１回目に一番左(mod CountIn == 0になる)がフラッシュする
+  int _metronomeContainerStatus = -1;
+  get metronomeContainerStatus => _metronomeContainerStatus;
+
+  int _countInTimes = 4;
+  get countInTimes => _countInTimes;
+
+  bool _isCountInPlaying = false;
+  get isCountInPlaying => _isCountInPlaying;
+
   void switchPlayStatus() {
     _isPlaying = !_isPlaying;
     notifyListeners();
@@ -229,9 +173,9 @@ class MetronomeModel extends ChangeNotifier {
     _isPlaying = false;
     _metronomeContainerStatus = -1;
     _metronomePlayer?.clearCache();
-    if (scrollController.hasClients) {
-      scrollController.jumpTo(0.0);
-    }
+    _hasScrolledDuringPlaying = false;
+    _scrollOffset = 0.0;
+    scrollToNowPlaying();
     notifyListeners();
   }
 
@@ -306,39 +250,6 @@ class MetronomeModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void decideRateToScroll() {
-    try {
-      for (int i = 0; i < _maxTickList.length; i++) {
-        if (deviceHeight / 2 <= _textFormOffsetList[i] &&
-            _metronomeContainerStatus == _maxTickList[i]) {
-          _scrollRate = _textFormOffsetList[i + 1] - deviceHeight / 2;
-          scrollToNowPlaying();
-        }
-      }
-      if (_metronomeContainerStatus >= _maxTickList.reduce(max)) {
-        _scrollRate = scrollController.position.maxScrollExtent;
-      }
-    } catch (e) {}
-  }
-
-  void scrollToNowPlaying() {
-    if (scrollController.hasClients) {
-      if (_scrollRate <= scrollController.position.maxScrollExtent) {
-        scrollController.animateTo(
-          _scrollRate,
-          curve: Curves.easeOut,
-          duration: Duration(milliseconds: 500),
-        );
-      } else {
-        scrollController.animateTo(
-          scrollController.position.maxScrollExtent,
-          curve: Curves.easeOut,
-          duration: Duration(milliseconds: 500),
-        );
-      }
-    }
-  }
-
   void metronomeClear() {
     _metronomeSubscription?.cancel();
   }
@@ -351,5 +262,106 @@ class MetronomeModel extends ChangeNotifier {
     }
     _audioPlayer.setVolume(_soundVolume);
     notifyListeners();
+  }
+
+  bool _hasScrolledDuringPlaying = false;
+  get hasScrolledDuringPlaying => _hasScrolledDuringPlaying;
+
+  double _scrollOffset = 0.0;
+  get scrollOffset => _scrollOffset;
+
+  //scrollable_pageビルド時に代入
+  double deviceHeight = 0;
+  ScrollController scrollController;
+  List<int> _maxTickList = [];
+
+  List<int> _ticksPerRowList = [];
+  get ticksPerRowList => _ticksPerRowList;
+  set ticksPerRowList(List<String> fetchedRhythmList) {
+    _ticksPerRowList = [];
+    if (fetchedRhythmList == []) {
+      _ticksPerRowList = [];
+    } else {
+      for (int i = 0; i < fetchedRhythmList.length; i++) {
+        List<String> beatCountList = fetchedRhythmList[i].split('/');
+        if (beatCountList[1] == "4") {
+          _ticksPerRowList.add(int.parse(beatCountList[0]));
+        } else if (beatCountList[1] == "8") {
+          _ticksPerRowList.add(int.parse(beatCountList[0]) ~/ 2);
+        } else if (beatCountList[1] == "16") {
+          _ticksPerRowList.add(int.parse(beatCountList[0]) ~/ 4);
+        }
+      }
+    }
+  }
+
+  List<double> _textFormOffsetList = [];
+  get textFormOffsetList => _textFormOffsetList;
+
+  set textFormOffsetList(double dy) {
+    if (dy == -1) {
+      //scrollablePage呼び出し時に初期化
+      _textFormOffsetList = [];
+    } else {
+      _textFormOffsetList.add(dy);
+    }
+  }
+
+  /// codeNumList : 一列あたりの小節数を受けてmetronomeContainerStatusの列ごとの最大数をリスト化
+  void setMaxTickList(int fetchedBarNum, [int listIndex]) {
+    if (fetchedBarNum == -1) {
+      //scrollablePage呼び出し時に初期化
+      _maxTickList = [];
+    } else {
+      if (listIndex == 0) {
+        _maxTickList.add(fetchedBarNum * _ticksPerRowList[listIndex]);
+      } else {
+        _maxTickList.add(_maxTickList[listIndex - 1] +
+            fetchedBarNum * _ticksPerRowList[listIndex]);
+      }
+    }
+  }
+
+  void enableScroll() {
+    _hasScrolledDuringPlaying = false;
+    notifyListeners();
+  }
+
+  void unableScroll() {
+    _hasScrolledDuringPlaying = true;
+    notifyListeners();
+  }
+
+  void decideRateToScroll() {
+    try {
+      for (int i = 0; i < _maxTickList.length; i++) {
+        if (deviceHeight / 2 <= _textFormOffsetList[i] &&
+            _metronomeContainerStatus == _maxTickList[i]) {
+          _scrollOffset = _textFormOffsetList[i + 1] - deviceHeight / 2;
+          scrollToNowPlaying();
+        }
+      }
+      if (_metronomeContainerStatus >= _maxTickList.reduce(max)) {
+        _scrollOffset = scrollController.position.maxScrollExtent;
+      }
+    } catch (e) {}
+  }
+
+  void scrollToNowPlaying() {
+    if (scrollController.hasClients && !_hasScrolledDuringPlaying) {
+      if (_scrollOffset <= scrollController.position.maxScrollExtent) {
+        scrollController.animateTo(
+          _scrollOffset,
+          curve: Curves.easeOut,
+          duration: Duration(milliseconds: 500),
+        );
+      } else {
+        scrollController.animateTo(
+          scrollController.position.maxScrollExtent,
+          curve: Curves.easeOut,
+          duration: Duration(milliseconds: 500),
+        );
+      }
+    }
   }
 }

--- a/lib/models/metronome_model.dart
+++ b/lib/models/metronome_model.dart
@@ -97,6 +97,19 @@ class MetronomeModel extends ChangeNotifier {
     }
   }
 
+  List<double> _textFormOffsetList = [];
+  get textFormOffsetList => _textFormOffsetList;
+
+  set textFormOffsetList(double dy) {
+    if (dy == -1) {
+      //scrollablePage呼び出し時に初期化
+      _textFormOffsetList = [];
+    } else {
+      _textFormOffsetList.add(dy);
+    }
+    print(_textFormOffsetList);
+  }
+
   Color _metronomeContainerColor;
   get metronomeContainerColor => _metronomeContainerColor;
 

--- a/lib/models/metronome_model.dart
+++ b/lib/models/metronome_model.dart
@@ -205,12 +205,6 @@ class MetronomeModel extends ChangeNotifier {
   }
 
   void metronomeStart() {
-    print("_textFormOffsetList : $_textFormOffsetList");
-    print("deviceHeight : $deviceHeight");
-    print("maxTickList : $_maxTickList");
-    print("ticksPerList : $_ticksPerRowList");
-    print("maxScroll : ${scrollController.position.maxScrollExtent}");
-
     const microseconds = 60000000;
     var _metronomeDuration =
         Duration(microseconds: (microseconds ~/ _tempoCount));

--- a/lib/models/metronome_model.dart
+++ b/lib/models/metronome_model.dart
@@ -97,6 +97,7 @@ class MetronomeModel extends ChangeNotifier {
     }
   }
 
+  double deviceHeight = 0;
   List<double> _textFormOffsetList = [];
   get textFormOffsetList => _textFormOffsetList;
 
@@ -107,7 +108,6 @@ class MetronomeModel extends ChangeNotifier {
     } else {
       _textFormOffsetList.add(dy);
     }
-    print(_textFormOffsetList);
   }
 
   Color _metronomeContainerColor;
@@ -261,6 +261,12 @@ class MetronomeModel extends ChangeNotifier {
   }
 
   void metronomeStart() {
+    print("_textFormOffsetList : $_textFormOffsetList");
+    print("deviceHeight : $deviceHeight");
+    print("maxTickList : $_maxTickList");
+    print("ticksPerList : $_ticksPerRowList");
+    print("maxScroll : ${scrollController.position.maxScrollExtent}");
+
     const microseconds = 60000000;
     var _metronomeDuration =
         Duration(microseconds: (microseconds ~/ _tempoCount));
@@ -302,31 +308,34 @@ class MetronomeModel extends ChangeNotifier {
 
   void decideRateToScroll() {
     try {
-      if (_metronomeContainerStatus >= 0 &&
-          _metronomeContainerStatus < _maxTickList[0]) {
-        _scrollRate = 0.0;
-        scrollToNowPlaying();
-      } else {
-        for (int i = 1; i < _maxTickList.length; i++) {
-          if (_metronomeContainerStatus >= _maxTickList[i - 1] &&
-              _metronomeContainerStatus < _maxTickList[i]) {
-            _scrollRate = i / (_maxTickList.length - 2);
-          } else if (_metronomeContainerStatus == _maxTickList[i]) {
-            scrollToNowPlaying();
-          }
+      for (int i = 0; i < _maxTickList.length; i++) {
+        if (deviceHeight / 2 <= _textFormOffsetList[i] &&
+            _metronomeContainerStatus == _maxTickList[i]) {
+          _scrollRate = _textFormOffsetList[i + 1] - deviceHeight / 2;
+          scrollToNowPlaying();
         }
       }
       if (_metronomeContainerStatus >= _maxTickList.reduce(max)) {
-        _scrollRate = 1.0;
+        _scrollRate = scrollController.position.maxScrollExtent;
       }
     } catch (e) {}
   }
 
   void scrollToNowPlaying() {
     if (scrollController.hasClients) {
-      scrollController.jumpTo(
-        scrollController.position.maxScrollExtent * _scrollRate,
-      );
+      if (_scrollRate <= scrollController.position.maxScrollExtent) {
+        scrollController.animateTo(
+          _scrollRate,
+          curve: Curves.easeOut,
+          duration: Duration(milliseconds: 500),
+        );
+      } else {
+        scrollController.animateTo(
+          scrollController.position.maxScrollExtent,
+          curve: Curves.easeOut,
+          duration: Duration(milliseconds: 500),
+        );
+      }
     }
   }
 

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -35,6 +35,9 @@ class _ScrollPageState extends State<ScrollablePage> {
   void initState() {
     super.initState();
     _scrollController = ScrollController();
+    Provider.of<MetronomeModel>(context, listen: false).setMaxTickList(-1);
+    Provider.of<MetronomeModel>(context, listen: false).scrollController =
+        _scrollController;
   }
 
   @override
@@ -118,16 +121,6 @@ class _ScrollPageState extends State<ScrollablePage> {
           Text("歌詞も表示する")
         ],
       ));
-
-      displayedList.add(TextButton(
-          onPressed: () {
-            _scrollController.animateTo(
-              _scrollController.position.maxScrollExtent,
-              curve: Curves.easeOut,
-              duration: const Duration(milliseconds: 10000),
-            );
-          },
-          child: Text("スクロール")));
       for (int listIndex = 0; listIndex < codeListState.length; listIndex++) {
         List<Widget> list = [];
         if (widget.separationList.length != 0) {
@@ -168,12 +161,15 @@ class _ScrollPageState extends State<ScrollablePage> {
           }
         }
 
-        Provider.of<MetronomeModel>(context, listen: false).rhythmNumList =
+        Provider.of<MetronomeModel>(context, listen: false).ticksPerRowList =
             widget.rhythmList;
+
+        Provider.of<MetronomeModel>(context, listen: false)
+            .setMaxTickList(codeListState[listIndex].length, listIndex);
 
         int eachBeatCount(int index) {
           return Provider.of<MetronomeModel>(context, listen: false)
-              .rhythmNumList[index];
+              .ticksPerRowList[index];
         }
 
         for (var i = 0; i < codeListState[listIndex].length; i++) {
@@ -233,17 +229,8 @@ class _ScrollPageState extends State<ScrollablePage> {
           ));
           list.add(Text("|"));
         }
-
         displayedList.add(Row(children: list));
       }
-
-      displayedList.add(TextButton(
-          onPressed: () {
-            _scrollController.jumpTo(
-              0.0,
-            );
-          },
-          child: Text("上まで戻る")));
 
       return displayedList;
     }

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -291,42 +291,68 @@ class _ScrollPageState extends State<ScrollablePage> {
         ],
       ));
     } else {
-      return Container(
-          child: Stack(
-        alignment: Alignment.bottomCenter,
-        children: [
-          Scrollbar(
-              // controller: _scrollController,
-              isAlwaysShown: false,
-              thickness: 8.0,
-              hoverThickness: 12.0,
-              child: SingleChildScrollView(
+      return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          child: Container(
+              child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              Scrollbar(
                   controller: _scrollController,
-                  child: ListView(
-                    padding: EdgeInsets.all(36.0),
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    children: displayedWidget(),
-                  ))),
-          Positioned(
-            bottom: 5,
-            child: Container(
-                width: 200,
-                decoration: BoxDecoration(
-                    color: Colors.grey.withOpacity(0.9),
-                    borderRadius: BorderRadius.all(Radius.circular(20))),
-                child: TextButton(
-                  child: Text("スクロールを\n再開する",
-                      style: TextStyle(fontSize: 16, color: Colors.white)),
-                  style: ButtonStyle(
-                      shape: MaterialStateProperty.all((RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
-                  )))),
-                  onPressed: () {},
-                )),
-          )
-        ],
-      ));
+                  isAlwaysShown: false,
+                  thickness: 8.0,
+                  hoverThickness: 12.0,
+                  child: SingleChildScrollView(
+                      controller: _scrollController,
+                      child: ListView(
+                        padding: EdgeInsets.all(36.0),
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        children: displayedWidget(),
+                      ))),
+              Selector<MetronomeModel, bool>(
+                  selector: (context, model) => model.hasScrolledDuringPlaying,
+                  shouldRebuild: (exScrollStatus, notifiedScrollStatus) =>
+                      exScrollStatus != notifiedScrollStatus,
+                  builder: (context, hasScrolledDuringPlaying, child) =>
+                      hasScrolledDuringPlaying &&
+                              Provider.of<MetronomeModel>(context,
+                                      listen: false)
+                                  .isPlaying
+                          ? Positioned(
+                              bottom: 5,
+                              child: Container(
+                                  width: 200,
+                                  decoration: BoxDecoration(
+                                      color: Colors.grey.withOpacity(0.9),
+                                      borderRadius: BorderRadius.all(
+                                          Radius.circular(20))),
+                                  child: TextButton(
+                                    child: Text("スクロールを\n再開する",
+                                        style: TextStyle(
+                                            fontSize: 16, color: Colors.white)),
+                                    style: ButtonStyle(
+                                        shape: MaterialStateProperty.all(
+                                            (RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(20),
+                                    )))),
+                                    onPressed: () {
+                                      Provider.of<MetronomeModel>(context,
+                                              listen: false)
+                                          .enableScroll();
+                                      Provider.of<MetronomeModel>(context,
+                                              listen: false)
+                                          .scrollToNowPlaying();
+                                    },
+                                  )),
+                            )
+                          : Container())
+            ],
+          )),
+          onTapDown: (_) {
+            print("Tapped");
+            Provider.of<MetronomeModel>(context, listen: false).unableScroll();
+          });
     }
   }
 }

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -350,7 +350,6 @@ class _ScrollPageState extends State<ScrollablePage> {
             ],
           )),
           onTapDown: (_) {
-            print("Tapped");
             Provider.of<MetronomeModel>(context, listen: false).unableScroll();
           });
     }

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -31,6 +31,8 @@ class _ScrollPageState extends State<ScrollablePage> {
   // コントローラ
   ScrollController _scrollController;
 
+  final List<GlobalKey> _globalTextFormList = [];
+
   @override
   void initState() {
     super.initState();
@@ -38,6 +40,7 @@ class _ScrollPageState extends State<ScrollablePage> {
     Provider.of<MetronomeModel>(context, listen: false).setMaxTickList(-1);
     Provider.of<MetronomeModel>(context, listen: false).scrollController =
         _scrollController;
+    Provider.of<MetronomeModel>(context, listen: false).textFormOffsetList = -1;
   }
 
   @override
@@ -161,6 +164,20 @@ class _ScrollPageState extends State<ScrollablePage> {
           }
         }
 
+        _globalTextFormList.add(GlobalKey<FormState>());
+
+        double _getLocaleAndSize(int listIndex) {
+          RenderBox box =
+              _globalTextFormList[listIndex].currentContext.findRenderObject();
+          return box.localToGlobal(Offset.zero).dy;
+        }
+
+        ///列ごとビルドされ、その時にビルドされたTextFormの位置dyをMetronomeModelに渡す
+        WidgetsBinding.instance.addPostFrameCallback((cb) {
+          Provider.of<MetronomeModel>(context, listen: false)
+              .textFormOffsetList = _getLocaleAndSize(listIndex);
+        });
+
         Provider.of<MetronomeModel>(context, listen: false).ticksPerRowList =
             widget.rhythmList;
 
@@ -220,6 +237,7 @@ class _ScrollPageState extends State<ScrollablePage> {
                       : Colors.transparent,
                   child: child),
               child: TextField(
+                key: i == 0 ? _globalTextFormList[listIndex] : null,
                 enabled: false,
                 textAlign: TextAlign.center,
                 controller:

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -25,12 +25,13 @@ class _ScrollPageState extends State<ScrollablePage> {
   void _handleCheckbox(bool e) {
     setState(() {
       _lyricsDisplayed = e;
+      Provider.of<MetronomeModel>(context, listen: false).textFormOffsetList =
+          -1;
     });
   }
 
   // コントローラ
   ScrollController _scrollController;
-
   final List<GlobalKey> _globalTextFormList = [];
 
   @override
@@ -51,6 +52,9 @@ class _ScrollPageState extends State<ScrollablePage> {
 
   @override
   Widget build(BuildContext context) {
+    Provider.of<MetronomeModel>(context, listen: false).deviceHeight =
+        MediaQuery.of(context).size.height;
+
     List<List<String>> codeListState = [];
     for (int i = 0; i < widget.codeList.length; i++) {
       List<String> oneLineCode = widget.codeList[i].split(",");

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -292,7 +292,10 @@ class _ScrollPageState extends State<ScrollablePage> {
       ));
     } else {
       return Container(
-          child: Scrollbar(
+          child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          Scrollbar(
               // controller: _scrollController,
               isAlwaysShown: false,
               thickness: 8.0,
@@ -304,7 +307,26 @@ class _ScrollPageState extends State<ScrollablePage> {
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
                     children: displayedWidget(),
-                  ))));
+                  ))),
+          Positioned(
+            bottom: 5,
+            child: Container(
+                width: 200,
+                decoration: BoxDecoration(
+                    color: Colors.grey.withOpacity(0.9),
+                    borderRadius: BorderRadius.all(Radius.circular(20))),
+                child: TextButton(
+                  child: Text("スクロールを\n再開する",
+                      style: TextStyle(fontSize: 16, color: Colors.white)),
+                  style: ButtonStyle(
+                      shape: MaterialStateProperty.all((RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  )))),
+                  onPressed: () {},
+                )),
+          )
+        ],
+      ));
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.6.1"
   audioplayers:
     dependency: "direct main"
     description:
@@ -49,7 +49,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
@@ -246,7 +246,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   nested:
     dependency: transitive
     description:
@@ -433,7 +433,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION

https://user-images.githubusercontent.com/81696417/131017686-0e5e3b54-5600-4ff2-a8fb-b126228020c2.mov

scrollablePageのビルド時にMetronomeModelに一列ごとの最大ティック数と、ScrollControllerそのまま渡すという荒技してる、もっといい方法はありそう。

またどこまでスクロールするかっていう割合がかなりむずそう、
「コードを編集する」「歌詞も表示する」
の二つのウィジェットがBodyからいなくなればText FIeldの高さ出すだけでいけそう