### PR TITLE
キーボードにフォームが隠れちゃうバグを治した

### DIFF
--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -133,23 +133,23 @@ class EditingSongModel extends ChangeNotifier {
 
   double deviceHeight = 0;
 
-  set codeFormOffsetList(double dy) {
-    double yOffset = dy;
-    if (dy == -1) {
+  set codeFormOffsetList(double yOffset) {
+    double tmp = yOffset;
+    if (yOffset == -1) {
       //scrollablePage呼び出し時に初期化
       _codeFormOffsetList = [];
     } else {
-      _codeFormOffsetList.add(yOffset);
+      _codeFormOffsetList.add(tmp);
     }
   }
 
-  set lyricFormOffsetList(double dy) {
-    double yOffset = dy;
-    if (dy == -1) {
+  set lyricFormOffsetList(double yOffset) {
+    double tmp = yOffset;
+    if (yOffset == -1) {
       //scrollablePage呼び出し時に初期化
       _lyricFormOffsetList = [];
     } else {
-      _lyricFormOffsetList.add(yOffset);
+      _lyricFormOffsetList.add(tmp);
     }
   }
 
@@ -180,7 +180,7 @@ class EditingSongModel extends ChangeNotifier {
     }
   }
 
-  void scrollToStart() {
+  void scrollToTop() {
     if (editScrollController.hasClients) {
       editScrollController.jumpTo(
         editScrollController.position.minScrollExtent,

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -155,18 +155,20 @@ class EditingSongModel extends ChangeNotifier {
     if (editScrollController.hasClients) {
       switch (mode) {
         case "code":
+          print(_codeFormOffsetList[listIndex]);
           editScrollController.animateTo(
             (_codeFormOffsetList[listIndex] > deviceHeight / 2)
-                ? _codeFormOffsetList[listIndex] - deviceHeight / 2
+                ? _codeFormOffsetList[listIndex] - (deviceHeight / 2)
                 : 0,
             duration: Duration(milliseconds: 500),
             curve: Curves.easeOut,
           );
           break;
-        case "lyric":
+        case "lyrics":
+          print(_lyricFormOffsetList[listIndex]);
           editScrollController.animateTo(
             (_lyricFormOffsetList[listIndex] > deviceHeight / 2)
-                ? _lyricFormOffsetList[listIndex] - deviceHeight / 2
+                ? _lyricFormOffsetList[listIndex] - (deviceHeight / 2)
                 : 0,
             duration: Duration(milliseconds: 500),
             curve: Curves.easeOut,

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -139,7 +139,7 @@ class EditingSongModel extends ChangeNotifier {
       //scrollablePage呼び出し時に初期化
       _codeFormOffsetList = [];
     } else {
-      _codeFormOffsetList.add(tmp);
+      _codeFormOffsetList.add(tmp + editScrollController.offset);
     }
   }
 
@@ -149,7 +149,7 @@ class EditingSongModel extends ChangeNotifier {
       //scrollablePage呼び出し時に初期化
       _lyricFormOffsetList = [];
     } else {
-      _lyricFormOffsetList.add(tmp);
+      _lyricFormOffsetList.add(tmp + editScrollController.offset);
     }
   }
 

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -199,7 +199,7 @@ class EditingSongModel extends ChangeNotifier {
 
   void openKeyboard() {
     _keyboardIsOpening = true;
-    _keyboardBottomSpace = 350;
+    _keyboardBottomSpace = 300;
     notifyListeners();
   }
 

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -134,20 +134,22 @@ class EditingSongModel extends ChangeNotifier {
   double deviceHeight = 0;
 
   set codeFormOffsetList(double dy) {
+    double yOffset = dy;
     if (dy == -1) {
       //scrollablePage呼び出し時に初期化
       _codeFormOffsetList = [];
     } else {
-      _codeFormOffsetList.add(dy);
+      _codeFormOffsetList.add(yOffset);
     }
   }
 
   set lyricFormOffsetList(double dy) {
+    double yOffset = dy;
     if (dy == -1) {
       //scrollablePage呼び出し時に初期化
       _lyricFormOffsetList = [];
     } else {
-      _lyricFormOffsetList.add(dy);
+      _lyricFormOffsetList.add(yOffset);
     }
   }
 
@@ -175,6 +177,14 @@ class EditingSongModel extends ChangeNotifier {
           );
           break;
       }
+    }
+  }
+
+  void scrollToStart() {
+    if (editScrollController.hasClients) {
+      editScrollController.jumpTo(
+        editScrollController.position.minScrollExtent,
+      );
     }
   }
 

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -155,20 +155,22 @@ class EditingSongModel extends ChangeNotifier {
     if (editScrollController.hasClients) {
       switch (mode) {
         case "code":
-          if (_codeFormOffsetList[listIndex] > deviceHeight / 2)
-            editScrollController.animateTo(
-              _codeFormOffsetList[listIndex] - deviceHeight / 2,
-              duration: Duration(milliseconds: 500),
-              curve: Curves.easeOut,
-            );
+          editScrollController.animateTo(
+            (_codeFormOffsetList[listIndex] > deviceHeight / 2)
+                ? _codeFormOffsetList[listIndex] - deviceHeight / 2
+                : 0,
+            duration: Duration(milliseconds: 500),
+            curve: Curves.easeOut,
+          );
           break;
         case "lyric":
-          if (_lyricFormOffsetList[listIndex] > deviceHeight / 2)
-            editScrollController.animateTo(
-              _lyricFormOffsetList[listIndex] - deviceHeight / 2,
-              duration: Duration(milliseconds: 500),
-              curve: Curves.easeOut,
-            );
+          editScrollController.animateTo(
+            (_lyricFormOffsetList[listIndex] > deviceHeight / 2)
+                ? _lyricFormOffsetList[listIndex] - deviceHeight / 2
+                : 0,
+            duration: Duration(milliseconds: 500),
+            curve: Curves.easeOut,
+          );
           break;
       }
     }

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -123,6 +123,19 @@ class EditingSongModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  ///detailEditPageビルド時に代入
+  ScrollController editScrollController;
+
+  void scrollToEnd() {
+    if (editScrollController.hasClients) {
+      editScrollController.animateTo(
+        editScrollController.position.maxScrollExtent,
+        duration: Duration(milliseconds: 500),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
   ///detail_edit_pageでTextFieldをTapする度に対応したTextEditingControllerを代入する
   TextEditingController controller;
   int controlBarIdx = 0;
@@ -254,11 +267,5 @@ class EditingSongModel extends ChangeNotifier {
 
   bool _isUtf16Surrogate(int value) {
     return value & 0xF800 == 0xD800;
-  }
-
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
   }
 }

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -126,6 +126,54 @@ class EditingSongModel extends ChangeNotifier {
   ///detailEditPageビルド時に代入
   ScrollController editScrollController;
 
+  List<double> _codeFormOffsetList = [];
+  List<double> _lyricFormOffsetList = [];
+  get codeFormOffsetList => _codeFormOffsetList;
+  get lyricFormOffsetList => _lyricFormOffsetList;
+
+  double deviceHeight = 0;
+
+  set codeFormOffsetList(double dy) {
+    if (dy == -1) {
+      //scrollablePage呼び出し時に初期化
+      _codeFormOffsetList = [];
+    } else {
+      _codeFormOffsetList.add(dy);
+    }
+  }
+
+  set lyricFormOffsetList(double dy) {
+    if (dy == -1) {
+      //scrollablePage呼び出し時に初期化
+      _lyricFormOffsetList = [];
+    } else {
+      _lyricFormOffsetList.add(dy);
+    }
+  }
+
+  void scrollToTappedForm({int listIndex, String mode}) {
+    if (editScrollController.hasClients) {
+      switch (mode) {
+        case "code":
+          if (_codeFormOffsetList[listIndex] > deviceHeight / 2)
+            editScrollController.animateTo(
+              _codeFormOffsetList[listIndex] - deviceHeight / 2,
+              duration: Duration(milliseconds: 500),
+              curve: Curves.easeOut,
+            );
+          break;
+        case "lyric":
+          if (_lyricFormOffsetList[listIndex] > deviceHeight / 2)
+            editScrollController.animateTo(
+              _lyricFormOffsetList[listIndex] - deviceHeight / 2,
+              duration: Duration(milliseconds: 500),
+              curve: Curves.easeOut,
+            );
+          break;
+      }
+    }
+  }
+
   void scrollToEnd() {
     if (editScrollController.hasClients) {
       editScrollController.animateTo(

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -21,7 +21,7 @@ class CustomKeyboard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 350,
+      height: 300,
       color: Colors.grey[800],
       child: Column(
         children: [
@@ -34,7 +34,7 @@ class CustomKeyboard extends StatelessWidget {
           buildRowThree(),
           insertPadding,
           buildRowFour(),
-          Padding(padding: EdgeInsets.only(bottom: 70))
+          Padding(padding: EdgeInsets.only(bottom: 30))
         ],
       ),
     );
@@ -42,7 +42,7 @@ class CustomKeyboard extends StatelessWidget {
 
   Container buildRowSetting(BuildContext context) {
     return Container(
-      height: 50,
+      height: 40,
       child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
         IconButton(
             icon: Icon(Icons.keyboard_arrow_down_outlined, color: Colors.grey),
@@ -55,6 +55,8 @@ class CustomKeyboard extends StatelessWidget {
             child: Padding(
                 padding: const EdgeInsets.fromLTRB(2.0, 8.0, 2.0, 2.0),
                 child: TextField(
+                    readOnly: true,
+                    showCursor: true,
                     cursorColor: Colors.white,
                     decoration: InputDecoration(
                         border: OutlineInputBorder(

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -189,7 +189,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                   Provider.of<EditingSongModel>(context, listen: false)
                       .openNormalKeyboard();
                   Provider.of<EditingSongModel>(context, listen: false)
-                      .scrollToTappedForm(listIndex: listIndex, mode: "lyric");
+                      .scrollToTappedForm(listIndex: listIndex, mode: "lyrics");
                 },
                 onChanged: (text) {
                   Provider.of<EditingSongModel>(context, listen: false)
@@ -474,10 +474,10 @@ class _DetailEditPageState extends State<DetailEditPage> {
                         isAlwaysShown: true,
                         thickness: 8.0,
                         hoverThickness: 12.0,
-                        child: Padding(
-                          padding: bottomPadding(context),
-                          child: SingleChildScrollView(
-                            controller: _scrollController,
+                        child: SingleChildScrollView(
+                          controller: _scrollController,
+                          child: Padding(
+                            padding: bottomPadding(context),
                             child: Center(child: Consumer<EditingSongModel>(
                                 builder: (_, model, __) {
                               return Column(
@@ -630,8 +630,9 @@ class _DetailEditPageState extends State<DetailEditPage> {
 
 EdgeInsets bottomPadding(context) {
   return EdgeInsets.only(
-      top: 24.0,
-      left: 24.0,
-      right: 8.0,
-      bottom: Provider.of<EditingSongModel>(context).keyboardBottomSpace);
+    top: 24.0,
+    left: 24.0,
+    right: 8.0,
+    bottom: 0,
+  ); //Provider.of<EditingSongModel>(context).keyboardBottomSpace);
 }

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -78,10 +78,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
               .lyricFormOffsetList = _getLyricLocale(listIndex);
         break;
     }
-    print(Provider.of<EditingSongModel>(context, listen: false)
-        .lyricFormOffsetList);
-    print(Provider.of<EditingSongModel>(context, listen: false)
-        .codeFormOffsetList);
   }
 
   @override

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -1,7 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_udid/flutter_udid.dart';
 import 'package:my_app/models/editing_song.dart';
 import 'package:provider/provider.dart';
 
@@ -215,7 +214,6 @@ class DetailEditPage extends StatelessWidget {
     }
 
     void submitCodeList(String docId) async {
-      String udid = await FlutterUdid.udid;
       FirebaseFirestore.instance.collection("Songs").doc(docId).update({
         "codeList": formatCodeList(
             Provider.of<EditingSongModel>(context, listen: false).codeList),
@@ -226,8 +224,6 @@ class DetailEditPage extends StatelessWidget {
         "lyricsList":
             Provider.of<EditingSongModel>(context, listen: false).lyricsList,
         "updatedAt": DateTime.now(),
-        "udid": udid,
-        "type": "edit",
       });
       Navigator.of(context).pop(
         MaterialPageRoute(builder: (context) {

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -42,6 +42,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
   }
 
   void _setEachOffsetList() {
+    print("set");
     _resetOffsetList();
     switch (Provider.of<EditingSongModel>(context, listen: false).displayType) {
       case "code":
@@ -86,6 +87,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
     _scrollController = ScrollController();
     Provider.of<EditingSongModel>(context, listen: false).editScrollController =
         _scrollController;
+    WidgetsBinding.instance.addPostFrameCallback((cb) => _setEachOffsetList());
   }
 
   @override
@@ -114,9 +116,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
   Widget build(BuildContext context) {
     Provider.of<EditingSongModel>(context, listen: false).deviceHeight =
         MediaQuery.of(context).size.height;
-
-    ///このWidgetがBuildされた時に呼ばれる
-    WidgetsBinding.instance.addPostFrameCallback((cb) => _setEachOffsetList());
 
     void _showCustomKeyboard(context) {
       Scaffold.of(context).showBottomSheet((BuildContext context) {
@@ -348,7 +347,11 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Navigator.pop(context),
                       Provider.of<EditingSongModel>(context, listen: false)
                           .setDisplayType("both"),
-                      _setEachOffsetList()
+                      //スクロール位置を戻してからWidget位置をSet
+                      Provider.of<EditingSongModel>(context, listen: false)
+                          .scrollToStart(),
+                      WidgetsBinding.instance
+                          .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
                   ),
                   // child: Text("コードと歌詞を編集"),
@@ -370,7 +373,11 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Navigator.pop(context),
                       Provider.of<EditingSongModel>(context, listen: false)
                           .setDisplayType("code"),
-                      _setEachOffsetList()
+                      //スクロール位置を戻してからWidget位置をSet
+                      Provider.of<EditingSongModel>(context, listen: false)
+                          .scrollToStart(),
+                      WidgetsBinding.instance
+                          .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
                   ),
                 ),
@@ -392,7 +399,11 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Navigator.pop(context),
                       Provider.of<EditingSongModel>(context, listen: false)
                           .setDisplayType("lyrics"),
-                      _setEachOffsetList()
+                      //スクロール位置を戻してからWidget位置をSet
+                      Provider.of<EditingSongModel>(context, listen: false)
+                          .scrollToStart(),
+                      WidgetsBinding.instance
+                          .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
                   ),
                 ),
@@ -622,7 +633,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                             })),
                           ),
                         ))),
-                //bottomSheet: CustomKeyboard(),
               )),
     );
   }
@@ -630,9 +640,8 @@ class _DetailEditPageState extends State<DetailEditPage> {
 
 EdgeInsets bottomPadding(context) {
   return EdgeInsets.only(
-    top: 24.0,
-    left: 24.0,
-    right: 8.0,
-    bottom: 0,
-  ); //Provider.of<EditingSongModel>(context).keyboardBottomSpace);
+      top: 24.0,
+      left: 24.0,
+      right: 8.0,
+      bottom: Provider.of<EditingSongModel>(context).keyboardBottomSpace);
 }

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -12,6 +12,8 @@ class DetailEditPage extends StatelessWidget {
   final String title;
   final String docId;
 
+  final ScrollController _scrollController = ScrollController();
+
   DetailEditPage({this.bpm, this.title, this.docId});
 
   List<String> formatCodeList(List<List<String>> codeList) {
@@ -32,6 +34,9 @@ class DetailEditPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Provider.of<EditingSongModel>(context, listen: false).editScrollController =
+        _scrollController;
+
     void _showCustomKeyboard(context) {
       Scaffold.of(context).showBottomSheet((BuildContext context) {
         return CustomKeyboard(
@@ -371,12 +376,14 @@ class DetailEditPage extends StatelessWidget {
                 },
                 child: Container(
                     child: Scrollbar(
+                        controller: _scrollController,
                         isAlwaysShown: true,
                         thickness: 8.0,
                         hoverThickness: 12.0,
                         child: Padding(
                           padding: bottomPadding(context),
                           child: SingleChildScrollView(
+                            controller: _scrollController,
                             child: Center(child: Consumer<EditingSongModel>(
                                 builder: (_, model, __) {
                               return Column(
@@ -508,8 +515,11 @@ class DetailEditPage extends StatelessWidget {
                                                       color: Colors.white)),
                                               style: ElevatedButton.styleFrom(
                                                   primary: Colors.orange),
-                                              onPressed: () {
+                                              onPressed: () async {
                                                 model.addEmptyList();
+                                                await Future.delayed(Duration(
+                                                    milliseconds: 200));
+                                                model.scrollToEnd();
                                               },
                                             )
                                           ])),

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_udid/flutter_udid.dart';
 import 'package:my_app/models/editing_song.dart';
 import 'package:provider/provider.dart';
 
@@ -304,6 +305,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
     }
 
     void submitCodeList(String docId) async {
+      String udid = await FlutterUdid.udid;
       FirebaseFirestore.instance.collection("Songs").doc(docId).update({
         "codeList": formatCodeList(
             Provider.of<EditingSongModel>(context, listen: false).codeList),
@@ -314,6 +316,8 @@ class _DetailEditPageState extends State<DetailEditPage> {
         "lyricsList":
             Provider.of<EditingSongModel>(context, listen: false).lyricsList,
         "updatedAt": DateTime.now(),
+        "udid": udid,
+        "type": "edit",
       });
       Navigator.of(context).pop(
         MaterialPageRoute(builder: (context) {

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -351,9 +351,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Navigator.pop(context),
                       Provider.of<EditingSongModel>(context, listen: false)
                           .setDisplayType("both"),
-                      //スクロール位置を戻してからWidget位置をSet
-                      Provider.of<EditingSongModel>(context, listen: false)
-                          .scrollToTop(),
                       WidgetsBinding.instance
                           .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
@@ -377,9 +374,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Navigator.pop(context),
                       Provider.of<EditingSongModel>(context, listen: false)
                           .setDisplayType("code"),
-                      //スクロール位置を戻してからWidget位置をSet
-                      Provider.of<EditingSongModel>(context, listen: false)
-                          .scrollToTop(),
                       WidgetsBinding.instance
                           .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
@@ -403,9 +397,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Navigator.pop(context),
                       Provider.of<EditingSongModel>(context, listen: false)
                           .setDisplayType("lyrics"),
-                      //スクロール位置を戻してからWidget位置をSet
-                      Provider.of<EditingSongModel>(context, listen: false)
-                          .scrollToTop(),
                       WidgetsBinding.instance
                           .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
@@ -629,6 +620,9 @@ class _DetailEditPageState extends State<DetailEditPage> {
                                                 await Future.delayed(Duration(
                                                     milliseconds: 200));
                                                 model.scrollToEnd();
+                                                WidgetsBinding.instance
+                                                    .addPostFrameCallback((cb) =>
+                                                        _setEachOffsetList());
                                               },
                                             )
                                           ])),

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -349,7 +349,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                           .setDisplayType("both"),
                       //スクロール位置を戻してからWidget位置をSet
                       Provider.of<EditingSongModel>(context, listen: false)
-                          .scrollToStart(),
+                          .scrollToTop(),
                       WidgetsBinding.instance
                           .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
@@ -375,7 +375,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                           .setDisplayType("code"),
                       //スクロール位置を戻してからWidget位置をSet
                       Provider.of<EditingSongModel>(context, listen: false)
-                          .scrollToStart(),
+                          .scrollToTop(),
                       WidgetsBinding.instance
                           .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },
@@ -401,7 +401,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                           .setDisplayType("lyrics"),
                       //スクロール位置を戻してからWidget位置をSet
                       Provider.of<EditingSongModel>(context, listen: false)
-                          .scrollToStart(),
+                          .scrollToTop(),
                       WidgetsBinding.instance
                           .addPostFrameCallback((cb) => _setEachOffsetList()),
                     },

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -295,58 +295,61 @@ class _ScrollPageState extends State<ScrollablePage> {
           behavior: HitTestBehavior.opaque,
           child: Container(
               child: Stack(
-            alignment: Alignment.bottomCenter,
+            alignment: Alignment.center,
             children: [
-              Scrollbar(
-                  controller: _scrollController,
-                  isAlwaysShown: false,
-                  thickness: 8.0,
-                  hoverThickness: 12.0,
-                  child: SingleChildScrollView(
-                      controller: _scrollController,
-                      child: ListView(
-                        padding: EdgeInsets.all(36.0),
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        children: displayedWidget(),
-                      ))),
-              Selector<MetronomeModel, bool>(
-                  selector: (context, model) => model.hasScrolledDuringPlaying,
-                  shouldRebuild: (exScrollStatus, notifiedScrollStatus) =>
-                      exScrollStatus != notifiedScrollStatus,
-                  builder: (context, hasScrolledDuringPlaying, child) =>
-                      hasScrolledDuringPlaying &&
-                              Provider.of<MetronomeModel>(context,
-                                      listen: false)
-                                  .isPlaying
-                          ? Positioned(
-                              bottom: 5,
-                              child: Container(
-                                  width: 200,
-                                  decoration: BoxDecoration(
-                                      color: Colors.grey.withOpacity(0.9),
-                                      borderRadius: BorderRadius.all(
-                                          Radius.circular(20))),
-                                  child: TextButton(
-                                    child: Text("スクロールを\n再開する",
-                                        style: TextStyle(
-                                            fontSize: 16, color: Colors.white)),
-                                    style: ButtonStyle(
-                                        shape: MaterialStateProperty.all(
-                                            (RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(20),
-                                    )))),
-                                    onPressed: () {
-                                      Provider.of<MetronomeModel>(context,
-                                              listen: false)
-                                          .enableScroll();
-                                      Provider.of<MetronomeModel>(context,
-                                              listen: false)
-                                          .scrollToNowPlaying();
-                                    },
-                                  )),
-                            )
-                          : Container())
+              Positioned(
+                child: Scrollbar(
+                    controller: _scrollController,
+                    isAlwaysShown: false,
+                    thickness: 8.0,
+                    hoverThickness: 12.0,
+                    child: SingleChildScrollView(
+                        controller: _scrollController,
+                        child: ListView(
+                          padding: EdgeInsets.all(36.0),
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          children: displayedWidget(),
+                        ))),
+              ),
+              Positioned(
+                bottom: 5,
+                child: Selector<MetronomeModel, bool>(
+                    selector: (context, model) =>
+                        model.hasScrolledDuringPlaying,
+                    shouldRebuild: (exScrollStatus, notifiedScrollStatus) =>
+                        exScrollStatus != notifiedScrollStatus,
+                    builder: (context, hasScrolledDuringPlaying, child) =>
+                        hasScrolledDuringPlaying &&
+                                Provider.of<MetronomeModel>(context,
+                                        listen: false)
+                                    .isPlaying
+                            ? Container(
+                                width: 200,
+                                decoration: BoxDecoration(
+                                    color: Colors.grey.withOpacity(0.9),
+                                    borderRadius:
+                                        BorderRadius.all(Radius.circular(20))),
+                                child: TextButton(
+                                  child: Text("スクロールを\n再開する",
+                                      style: TextStyle(
+                                          fontSize: 16, color: Colors.white)),
+                                  style: ButtonStyle(
+                                      shape: MaterialStateProperty.all(
+                                          (RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(20),
+                                  )))),
+                                  onPressed: () {
+                                    Provider.of<MetronomeModel>(context,
+                                            listen: false)
+                                        .enableScroll();
+                                    Provider.of<MetronomeModel>(context,
+                                            listen: false)
+                                        .scrollToNowPlaying();
+                                  },
+                                ))
+                            : Container()),
+              )
             ],
           )),
           onTapDown: (_) {

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -30,9 +30,14 @@ class _ScrollPageState extends State<ScrollablePage> {
     });
   }
 
-  // コントローラ
   ScrollController _scrollController;
   final List<GlobalKey> _globalTextFormList = [];
+
+  double _getLocaleAndSize(int listIndex) {
+    RenderBox box =
+        _globalTextFormList[listIndex].currentContext.findRenderObject();
+    return box.localToGlobal(Offset.zero).dy;
+  }
 
   @override
   void initState() {
@@ -169,12 +174,6 @@ class _ScrollPageState extends State<ScrollablePage> {
         }
 
         _globalTextFormList.add(GlobalKey<FormState>());
-
-        double _getLocaleAndSize(int listIndex) {
-          RenderBox box =
-              _globalTextFormList[listIndex].currentContext.findRenderObject();
-          return box.localToGlobal(Offset.zero).dy;
-        }
 
         ///列ごとビルドされ、その時にビルドされたTextFormの位置dyをMetronomeModelに渡す
         WidgetsBinding.instance.addPostFrameCallback((cb) {

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -294,23 +294,21 @@ class _ScrollPageState extends State<ScrollablePage> {
           behavior: HitTestBehavior.opaque,
           child: Container(
               child: Stack(
-            alignment: Alignment.center,
+            alignment: Alignment.topCenter,
             children: [
-              Positioned(
-                child: Scrollbar(
-                    controller: _scrollController,
-                    isAlwaysShown: false,
-                    thickness: 8.0,
-                    hoverThickness: 12.0,
-                    child: SingleChildScrollView(
-                        controller: _scrollController,
-                        child: ListView(
-                          padding: EdgeInsets.all(36.0),
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          children: displayedWidget(),
-                        ))),
-              ),
+              Scrollbar(
+                  controller: _scrollController,
+                  isAlwaysShown: false,
+                  thickness: 8.0,
+                  hoverThickness: 12.0,
+                  child: SingleChildScrollView(
+                      controller: _scrollController,
+                      child: ListView(
+                        padding: EdgeInsets.all(36.0),
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        children: displayedWidget(),
+                      ))),
               Positioned(
                 bottom: 5,
                 child: Selector<MetronomeModel, bool>(


### PR DESCRIPTION
**タップしたTextFormが真ん中に来るようにスクロールする**

・実装したこと
再生中の色付きのとこにスクロール合わせるのとほぼ一緒、
`WidgetsBinding.instance.addPostFrameCallback((cb) => _setEachOffsetList()),`
でWidgetがビルドされた後に_setEachOffsetListで列ごとのWidgetのy座標をリストに追加
→タップされたFormのlistIndexを渡してListのlistIndex番目の座標にスクロールする感じ

・気を付けるべきこと
WidgetsBinding.instance.addPostFrameCallback　は便利だけど、initState()の中に置くと最初に一度だけ・WIdget(BuildContext context)以下の中におくとそれがビルドされるごとに呼ばれるから使い分け必要

ウィジェットの座標はその時ビルドされた位置を0として計算するっぽいから、例えば編集中に「コードのみ表示」とかの表示を切り替えると、今表示してる箇所がy = 0とかになってTop部分が-1400とかになっちゃってた
→コードのみ、歌詞のみとか切り替える時は先頭にスクロールしてから位置を計算するようにしたら解決した

ついでにキーボードの高さとか元に戻したり、Editing Song PageをStateful(State自体はProviderで管理)で書いたりした

https://user-images.githubusercontent.com/81696417/131342814-c129ce45-fd9f-46b6-8923-b237bdb6df86.mov

