### PR TITLE
Dark modeに対応した

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:my_app/models/auth_model.dart';
 import 'package:my_app/models/editing_song.dart';
 import 'package:my_app/models/metronome_model.dart';
+import 'package:my_app/models/theme_model.dart';
 import 'package:my_app/pages/songs_list.dart';
 import 'package:provider/provider.dart';
 
@@ -24,15 +25,17 @@ class MyApp extends StatelessWidget {
           ChangeNotifierProvider<EditingSongModel>(
             create: (_) => EditingSongModel(),
           ),
-        ],
-        child: MaterialApp(
-          title: 'Code Scrolling',
-          theme: ThemeData(
-            primarySwatch: Colors.grey,
-            primaryColor: Colors.white,
+          ChangeNotifierProvider<ThemeModel>(
+            create: (_) => ThemeModel(),
           ),
-          darkTheme: ThemeData.dark(),
-          home: SongsList(),
-        ));
+        ],
+        child: Consumer<ThemeModel>(builder: (context, theme, _) {
+          return MaterialApp(
+            title: 'Code Scrolling',
+            theme: theme.currentTheme,
+            darkTheme: theme.themeIndex == 0 ? ThemeData.dark() : null,
+            home: SongsList(),
+          );
+        }));
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -27,7 +27,11 @@ class MyApp extends StatelessWidget {
         ],
         child: MaterialApp(
           title: 'Code Scrolling',
-          theme: ThemeData(primarySwatch: Colors.blueGrey),
+          theme: ThemeData(
+            primarySwatch: Colors.grey,
+            primaryColor: Colors.white,
+          ),
+          darkTheme: ThemeData.dark(),
           home: SongsList(),
         ));
   }

--- a/lib/models/theme_model.dart
+++ b/lib/models/theme_model.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 class ThemeModel extends ChangeNotifier {
   ThemeData _currentTheme = ThemeData(
-    primarySwatch: Colors.grey,
     primaryColor: Colors.white,
   );
   get currentTheme => _currentTheme;
@@ -15,7 +14,6 @@ class ThemeModel extends ChangeNotifier {
       case 0:
         _themeIndex = fetchedIndex;
         _currentTheme = ThemeData(
-          primarySwatch: Colors.grey,
           primaryColor: Colors.white,
         );
         break;
@@ -23,7 +21,6 @@ class ThemeModel extends ChangeNotifier {
       case 1:
         _themeIndex = fetchedIndex;
         _currentTheme = ThemeData(
-          primarySwatch: Colors.grey,
           primaryColor: Colors.white,
         );
         break;

--- a/lib/models/theme_model.dart
+++ b/lib/models/theme_model.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class ThemeModel extends ChangeNotifier {
+  ThemeData _currentTheme = ThemeData(
+    primarySwatch: Colors.grey,
+    primaryColor: Colors.white,
+  );
+  get currentTheme => _currentTheme;
+
+  //  themeIndex = 0:自動, 1:ライトモード, 2:ダークモード
+  int _themeIndex = 0;
+  get themeIndex => _themeIndex;
+  set themeIndex(int fetchedIndex) {
+    switch (fetchedIndex) {
+      case 0:
+        _themeIndex = fetchedIndex;
+        _currentTheme = ThemeData(
+          primarySwatch: Colors.grey,
+          primaryColor: Colors.white,
+        );
+        break;
+
+      case 1:
+        _themeIndex = fetchedIndex;
+        _currentTheme = ThemeData(
+          primarySwatch: Colors.grey,
+          primaryColor: Colors.white,
+        );
+        break;
+
+      case 2:
+        _themeIndex = fetchedIndex;
+        _currentTheme = ThemeData.dark();
+        break;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/pages/create_song.dart
+++ b/lib/pages/create_song.dart
@@ -105,6 +105,7 @@ class _CreateSongFormState extends State<CreateSong> {
               Navigator.pop(context);
             },
             child: CupertinoPicker(
+              backgroundColor: Theme.of(context).primaryColorLight,
               itemExtent: 40,
               children: _items.map(_pickerItem).toList(),
               onSelectedItemChanged: _onSelectedItemChanged,
@@ -153,8 +154,7 @@ class _CreateSongFormState extends State<CreateSong> {
           title: Text('曲追加ページ'),
           actions: [
             TextButton(
-              child: Text("作成",
-                  style: TextStyle(color: Colors.white, fontSize: 18)),
+              child: Text("作成", style: TextStyle(fontSize: 18)),
               onPressed: () {
                 if (_formKey.currentState.validate()) {
                   createButtonClicked();
@@ -176,68 +176,80 @@ class _CreateSongFormState extends State<CreateSong> {
                       Padding(
                           padding: EdgeInsets.only(bottom: 10.0),
                           child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
+                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                               children: <Widget>[
-                                Expanded(
-                                    child: OutlinedButton(
-                                  onPressed: () => {
-                                    Navigator.of(context).push(
-                                      MaterialPageRoute(builder: (context) {
-                                        return ImportSongById();
-                                      }),
+                                SizedBox(
+                                  height: MediaQuery.of(context).size.width / 3,
+                                  width: MediaQuery.of(context).size.width / 3,
+                                  child: OutlinedButton(
+                                    onPressed: () => {
+                                      Navigator.of(context).push(
+                                        MaterialPageRoute(builder: (context) {
+                                          return ImportSongById();
+                                        }),
+                                      ),
+                                    },
+                                    style: TextButton.styleFrom(
+                                      padding: EdgeInsets.only(
+                                          top: 12.0, bottom: 12.0),
+                                      textStyle: const TextStyle(fontSize: 16),
                                     ),
-                                  },
-                                  style: TextButton.styleFrom(
-                                    primary: Colors.black,
-                                    padding: EdgeInsets.only(
-                                        top: 12.0, bottom: 12.0),
-                                    textStyle: const TextStyle(fontSize: 16),
+                                    child: Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: <Widget>[
+                                          IconButton(
+                                            icon: const Icon(Icons.edit),
+                                            onPressed: null,
+                                          ),
+                                          Text('IDから\n追加する',
+                                              textAlign: TextAlign.center,
+                                              style: TextStyle(
+                                                  color: Theme.of(context)
+                                                      .primaryTextTheme
+                                                      .caption
+                                                      .color)),
+                                        ]),
                                   ),
-                                  child: Column(
+                                ),
+                                SizedBox(
+                                  height: MediaQuery.of(context).size.width / 3,
+                                  width: MediaQuery.of(context).size.width / 3,
+                                  child: OutlinedButton(
+                                    onPressed: () => {
+                                      Navigator.of(context).push(
+                                        MaterialPageRoute(builder: (context) {
+                                          return ImportSong();
+                                        }),
+                                      ),
+                                    },
+                                    style: TextButton.styleFrom(
+                                      padding: EdgeInsets.only(
+                                          top: 12.0, bottom: 12.0),
+                                      textStyle: const TextStyle(fontSize: 16),
+                                    ),
+                                    child: Column(
                                       mainAxisSize: MainAxisSize.min,
                                       children: <Widget>[
                                         IconButton(
-                                          icon: const Icon(Icons.edit),
+                                          icon: const Icon(Icons.qr_code),
                                           onPressed: null,
                                         ),
                                         Text(
-                                          'IDから\n追加する',
+                                          'QRコードから\n追加する',
                                           textAlign: TextAlign.center,
+                                          style: TextStyle(
+                                              color: Theme.of(context)
+                                                  .primaryTextTheme
+                                                  .caption
+                                                  .color),
                                         ),
-                                      ]),
-                                )),
-                                Expanded(
-                                    child: OutlinedButton(
-                                  onPressed: () => {
-                                    Navigator.of(context).push(
-                                      MaterialPageRoute(builder: (context) {
-                                        return ImportSong();
-                                      }),
+                                      ],
                                     ),
-                                  },
-                                  style: TextButton.styleFrom(
-                                    primary: Colors.black,
-                                    padding: EdgeInsets.only(
-                                        top: 12.0, bottom: 12.0),
-                                    textStyle: const TextStyle(fontSize: 16),
                                   ),
-                                  child: Column(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: <Widget>[
-                                      IconButton(
-                                        icon: const Icon(Icons.qr_code),
-                                        onPressed: null,
-                                      ),
-                                      Text(
-                                        'QRコードから\n追加する',
-                                        textAlign: TextAlign.center,
-                                      ),
-                                    ],
-                                  ),
-                                )),
+                                ),
                               ])),
                       TextFormField(
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 25.0,
                         ),
                         decoration: const InputDecoration(
@@ -246,7 +258,6 @@ class _CreateSongFormState extends State<CreateSong> {
                               child: Icon(Icons.music_note, size: 30.0)),
                           labelText: '曲名',
                         ),
-                        cursorColor: Colors.black,
                         onChanged: _handleTitle,
                         // ignore: missing_return
                         validator: (value) {
@@ -256,16 +267,15 @@ class _CreateSongFormState extends State<CreateSong> {
                         },
                       ),
                       TextFormField(
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 25.0,
                         ),
                         decoration: const InputDecoration(
                           icon: Padding(
                               padding: EdgeInsets.only(top: 10.0),
-                              child: Icon(Icons.person, size: 30.0)),
+                              child: const Icon(Icons.person, size: 30.0)),
                           labelText: 'アーティスト',
                         ),
-                        cursorColor: Colors.black,
                         onChanged: _handleArtist,
                         // ignore: missing_return
                         validator: (value) {
@@ -275,23 +285,30 @@ class _CreateSongFormState extends State<CreateSong> {
                         },
                       ),
                       Padding(
-                          padding: EdgeInsets.only(top: 20.0),
+                          padding: const EdgeInsets.only(top: 20.0),
                           child: Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: <Widget>[
                                 Text(
                                   "キー  ",
                                   style: TextStyle(
+                                    color: Theme.of(context)
+                                        .primaryTextTheme
+                                        .bodyText1
+                                        .color,
                                     fontSize: 25.0,
                                   ),
                                 ),
                                 OutlinedButton(
                                   child: Text((_key == "未選択") ? "キーを選択" : _key,
                                       style: TextStyle(
+                                        color: Theme.of(context)
+                                            .primaryTextTheme
+                                            .bodyText1
+                                            .color,
                                         fontSize: 25.0,
                                       )),
                                   style: OutlinedButton.styleFrom(
-                                    primary: Colors.black,
                                     side: const BorderSide(),
                                   ),
                                   onPressed: () {
@@ -314,14 +331,13 @@ class _CreateSongFormState extends State<CreateSong> {
                       Text(
                         "いつでも変更可能です",
                         style: TextStyle(
-                          color: Colors.grey,
+                          color:
+                              Theme.of(context).primaryTextTheme.caption.color,
                           fontSize: 15.0,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
                       Slider(
-                        activeColor: Colors.black,
-                        inactiveColor: Theme.of(context).primaryColorDark,
                         label: null,
                         value: _bpm.toDouble(),
                         divisions: 270,

--- a/lib/pages/detail_page/bpm_setting.dart
+++ b/lib/pages/detail_page/bpm_setting.dart
@@ -5,7 +5,6 @@ import '../../models/metronome_model.dart';
 
 class BpmSetting extends StatelessWidget {
   final double tempoIconSize = 32;
-  final Color textColor = Colors.white;
 
   @override
   Widget build(BuildContext context) {
@@ -13,75 +12,85 @@ class BpmSetting extends StatelessWidget {
       return SizedBox(
         height: MediaQuery.of(context).size.height / 2,
         width: MediaQuery.of(context).size.width,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+        child: Stack(
+          alignment: Alignment.center,
           children: [
-            Flexible(
-                flex: 1,
-                child: Text(
-                  "Tempo",
-                  style: TextStyle(
-                    fontSize: 32,
-                    color: textColor,
-                  ),
-                )),
-            Flexible(
-              flex: 1,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  IconButton(
-                      color: textColor,
-                      icon: Icon(Icons.remove),
-                      iconSize: tempoIconSize,
-                      tooltip: 'Decrement',
-                      onPressed: () {
-                        model.tempoDown();
-                      }),
-                  Text(
-                    model.tempoCount.toString(),
-                    style: TextStyle(
-                      fontSize: tempoIconSize * 2,
-                      color: textColor,
-                    ),
-                  ),
-                  IconButton(
-                      color: textColor,
-                      icon: Icon(Icons.add),
-                      iconSize: tempoIconSize,
-                      tooltip: 'Increment',
-                      onPressed: () {
-                        model.tempoUp();
-                      }),
-                ],
+            Positioned(
+              top: 10,
+              child: Container(
+                height: 5,
+                width: MediaQuery.of(context).size.width / 3,
+                decoration: BoxDecoration(
+                  color: Colors.grey,
+                  borderRadius: BorderRadius.circular(18.0),
+                ),
               ),
             ),
-            Flexible(
-              flex: 1,
-              child: Slider(
-                activeColor: textColor,
-                inactiveColor: Theme.of(context).primaryColorDark,
-                label: null,
-                value: model.tempoCount.toDouble(),
-                divisions: 270,
-                min: 30,
-                max: 300,
-                onChangeStart: model.startSlider,
-                onChanged: model.changeSlider,
-                onChangeEnd: model.endSlider,
-              ),
-            ),
-            Flexible(
-              flex: 1,
-              child: ElevatedButton(
-                  onPressed: () {
-                    model.bpmTapDetector();
-                  },
-                  child: Text(model.bpmTapText,
-                      style: TextStyle(fontSize: tempoIconSize * 0.75)),
-                  style: model.bpmTapCount % 5 != 0
-                      ? ElevatedButton.styleFrom(primary: Colors.red)
-                      : ElevatedButton.styleFrom()),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Flexible(
+                    flex: 1,
+                    child: Text(
+                      "Tempo",
+                      style: TextStyle(
+                        fontSize: 32,
+                      ),
+                    )),
+                Flexible(
+                  flex: 1,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      IconButton(
+                          icon: Icon(Icons.remove),
+                          iconSize: tempoIconSize,
+                          tooltip: 'Decrement',
+                          onPressed: () {
+                            model.tempoDown();
+                          }),
+                      Text(
+                        model.tempoCount.toString(),
+                        style: TextStyle(
+                          fontSize: tempoIconSize * 2,
+                        ),
+                      ),
+                      IconButton(
+                          icon: Icon(Icons.add),
+                          iconSize: tempoIconSize,
+                          tooltip: 'Increment',
+                          onPressed: () {
+                            model.tempoUp();
+                          }),
+                    ],
+                  ),
+                ),
+                Flexible(
+                  flex: 1,
+                  child: Slider(
+                    label: null,
+                    value: model.tempoCount.toDouble(),
+                    divisions: 270,
+                    min: 30,
+                    max: 300,
+                    onChangeStart: model.startSlider,
+                    onChanged: model.changeSlider,
+                    onChangeEnd: model.endSlider,
+                  ),
+                ),
+                Flexible(
+                  flex: 1,
+                  child: ElevatedButton(
+                      onPressed: () {
+                        model.bpmTapDetector();
+                      },
+                      child: Text(model.bpmTapText,
+                          style: TextStyle(fontSize: tempoIconSize * 0.75)),
+                      style: model.bpmTapCount % 5 != 0
+                          ? ElevatedButton.styleFrom(primary: Colors.red)
+                          : ElevatedButton.styleFrom()),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/pages/detail_page/detail_bottom_bar.dart
+++ b/lib/pages/detail_page/detail_bottom_bar.dart
@@ -8,10 +8,10 @@ import 'countin_dialog.dart';
 
 Material detailBottomBar(BuildContext context) {
   final double bottomIconSIze = 36;
-  final Color textColor = Colors.white;
+  final Color textColor = Colors.black;
 
   return Material(
-    color: Theme.of(context).primaryColor,
+    color: Theme.of(context).primaryColor.withOpacity(0.5),
     child: Container(
         width: MediaQuery.of(context).size.width,
         height: 100,
@@ -145,8 +145,8 @@ Material detailBottomBar(BuildContext context) {
 
 Icon volumeIcon(double soundVolume) {
   if (soundVolume == 0) {
-    return Icon(Icons.volume_off, color: Colors.white);
+    return Icon(Icons.volume_off, color: Colors.black);
   } else {
-    return Icon(Icons.volume_up, color: Colors.white);
+    return Icon(Icons.volume_up, color: Colors.black);
   }
 }

--- a/lib/pages/detail_page/detail_bottom_bar.dart
+++ b/lib/pages/detail_page/detail_bottom_bar.dart
@@ -8,7 +8,6 @@ import 'countin_dialog.dart';
 
 Material detailBottomBar(BuildContext context) {
   final double bottomIconSIze = 36;
-  final Color textColor = Colors.black;
 
   return Material(
     color: Theme.of(context).primaryColor.withOpacity(0.5),
@@ -48,14 +47,18 @@ Material detailBottomBar(BuildContext context) {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text("BPM", style: TextStyle(color: textColor)),
+                    Text("BPM",
+                        style: TextStyle(
+                            color: Theme.of(context).iconTheme.color)),
                     Selector<MetronomeModel, int>(
                         selector: (context, model) => model.tempoCount,
                         shouldRebuild: (exTempoCount, notifiedTempoCount) =>
                             exTempoCount != notifiedTempoCount,
                         builder: (context, tempoCount, child) => Text(
                               tempoCount.toString(),
-                              style: TextStyle(fontSize: 20, color: textColor),
+                              style: TextStyle(
+                                  fontSize: 20,
+                                  color: Theme.of(context).iconTheme.color),
                             )),
                   ],
                 ),
@@ -70,7 +73,6 @@ Material detailBottomBar(BuildContext context) {
               flex: 1,
               child: !isPlaying
                   ? IconButton(
-                      color: textColor,
                       icon: Icon(Icons.play_arrow_rounded),
                       iconSize: bottomIconSIze,
                       onPressed: () async {
@@ -98,7 +100,6 @@ Material detailBottomBar(BuildContext context) {
                       },
                     )
                   : IconButton(
-                      color: textColor,
                       icon: Icon(Icons.pause_rounded),
                       iconSize: bottomIconSIze,
                       onPressed: () {
@@ -114,7 +115,6 @@ Material detailBottomBar(BuildContext context) {
           Expanded(
             flex: 1,
             child: IconButton(
-              color: textColor,
               icon: Icon(Icons.stop_rounded),
               iconSize: bottomIconSIze,
               onPressed: () {
@@ -130,7 +130,6 @@ Material detailBottomBar(BuildContext context) {
                 shouldRebuild: (exSoundValue, notifiedSoundValue) =>
                     exSoundValue != notifiedSoundValue,
                 builder: (context, soundVolume, __) => IconButton(
-                      color: textColor,
                       icon: volumeIcon(soundVolume),
                       iconSize: bottomIconSIze,
                       onPressed: () {
@@ -145,8 +144,8 @@ Material detailBottomBar(BuildContext context) {
 
 Icon volumeIcon(double soundVolume) {
   if (soundVolume == 0) {
-    return Icon(Icons.volume_off, color: Colors.black);
+    return Icon(Icons.volume_off);
   } else {
-    return Icon(Icons.volume_up, color: Colors.black);
+    return Icon(Icons.volume_up);
   }
 }

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -574,9 +574,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                                                       value: model
                                                           .selectedBeatCount,
                                                       elevation: 16,
-                                                      style: const TextStyle(
-                                                        color: Colors.black,
-                                                      ),
                                                       onChanged:
                                                           (int newValue) {
                                                         model

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -436,8 +436,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                 showDisplayTypeDialog();
               }),
           TextButton(
-            child:
-                Text("完了", style: TextStyle(color: Colors.white, fontSize: 18)),
+            child: Text("完了", style: TextStyle(fontSize: 18)),
             onPressed: () {
               if (Provider.of<EditingSongModel>(context, listen: false)
                   .normalKeyboardIsOpen) {
@@ -514,9 +513,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                                                       value: model
                                                           .selectedSeparation,
                                                       elevation: 16,
-                                                      style: const TextStyle(
-                                                        color: Colors.black,
-                                                      ),
                                                       onChanged:
                                                           (String newValue) {
                                                         model
@@ -549,9 +545,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
                                                       value:
                                                           model.selectedRhythm,
                                                       elevation: 16,
-                                                      style: const TextStyle(
-                                                        color: Colors.black,
-                                                      ),
                                                       onChanged:
                                                           (String newValue) {
                                                         model.setSelectedRhythm(

--- a/lib/pages/detail_page/lyrics_page.dart
+++ b/lib/pages/detail_page/lyrics_page.dart
@@ -248,6 +248,7 @@ class _ScrollLyricsPageState extends State<LyricsPage> {
                 left: 10.0,
                 child: SvgPicture.asset(
                   turtleIcon,
+                  color: Theme.of(context).iconTheme.color,
                   semanticsLabel: 'turtle',
                   width: 30.0,
                 )),
@@ -286,6 +287,7 @@ class _ScrollLyricsPageState extends State<LyricsPage> {
                 right: 15.0,
                 child: SvgPicture.asset(
                   rabbitIcon,
+                  color: Theme.of(context).iconTheme.color,
                   semanticsLabel: 'rabbit',
                   width: 30.0,
                 )),

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -26,7 +26,7 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
               ),
             ),
             ListTile(
-              tileColor: Colors.grey,
+              tileColor: Theme.of(context).primaryColorLight,
               title: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -63,10 +63,10 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
                 alignedDropdown: true,
                 child: Consumer<MetronomeModel>(builder: (_, model, __) {
                   return Container(
-                      color: Colors.grey,
+                      color: Theme.of(context).primaryColorLight,
                       child: DropdownButton<int>(
                         isExpanded: true,
-                        dropdownColor: Theme.of(context).primaryColorDark,
+                        dropdownColor: Theme.of(context).primaryColorLight,
                         value: model.metronomeSoundsList
                             .indexOf(model.metronomeSound),
                         elevation: 16,
@@ -91,7 +91,7 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
               ),
             ),
             ListTile(
-                tileColor: Colors.grey,
+                tileColor: Theme.of(context).primaryColorLight,
                 title: Consumer<MetronomeModel>(builder: (_, model, __) {
                   return Text(
                     "回数：" + model.countInTimes.toString(),
@@ -104,8 +104,6 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
             insertPadding,
             ElevatedButton(
               child: Text("曲を削除する", style: TextStyle(color: Colors.red)),
-              style: ElevatedButton.styleFrom(
-                  primary: Theme.of(context).primaryColorLight),
               onPressed: () {
                 showDialog(
                     context: context,

--- a/lib/pages/detail_page/settings_drawer.dart
+++ b/lib/pages/detail_page/settings_drawer.dart
@@ -23,20 +23,17 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
               "曲情報",
               style: TextStyle(
                 fontSize: titleTextFont,
-                color: Colors.white,
               ),
             ),
             ListTile(
-              tileColor: Theme.of(context).primaryColorDark,
+              tileColor: Colors.grey,
               title: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text("曲名：" + title, style: TextStyle(color: Colors.white)),
-                  Text("アーティスト：" + artist,
-                      style: TextStyle(color: Colors.white)),
-                  Text("キー：" + songKey, style: TextStyle(color: Colors.white)),
-                  Text("BPM：" + bpm.toString(),
-                      style: TextStyle(color: Colors.white)),
+                  Text("曲名：" + title),
+                  Text("アーティスト：" + artist),
+                  Text("キー：" + songKey),
+                  Text("BPM：" + bpm.toString()),
                 ],
               ),
               onTap: () {
@@ -60,23 +57,19 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
               "メトロノームのサウンド",
               style: TextStyle(
                 fontSize: titleTextFont,
-                color: Colors.white,
               ),
             ),
             ButtonTheme(
                 alignedDropdown: true,
                 child: Consumer<MetronomeModel>(builder: (_, model, __) {
                   return Container(
-                      color: Theme.of(context).primaryColorDark,
+                      color: Colors.grey,
                       child: DropdownButton<int>(
                         isExpanded: true,
                         dropdownColor: Theme.of(context).primaryColorDark,
                         value: model.metronomeSoundsList
                             .indexOf(model.metronomeSound),
                         elevation: 16,
-                        style: const TextStyle(
-                          color: Colors.white,
-                        ),
                         onChanged: (int newValue) {
                           model.metronomeSound = newValue;
                         },
@@ -95,14 +88,14 @@ Drawer settingsDrawer(BuildContext context, int bpm, String title,
               "カウントイン",
               style: TextStyle(
                 fontSize: titleTextFont,
-                color: Colors.white,
               ),
             ),
             ListTile(
-                tileColor: Theme.of(context).primaryColorDark,
+                tileColor: Colors.grey,
                 title: Consumer<MetronomeModel>(builder: (_, model, __) {
-                  return Text("回数：" + model.countInTimes.toString(),
-                      style: TextStyle(color: Colors.white));
+                  return Text(
+                    "回数：" + model.countInTimes.toString(),
+                  );
                 }),
                 onTap: () {
                   print("Count-in Times");

--- a/lib/pages/export_song.dart
+++ b/lib/pages/export_song.dart
@@ -36,7 +36,6 @@ class ExportSong extends StatelessWidget {
               OutlinedButton(
                 child: const Text('IDをコピーする'),
                 style: OutlinedButton.styleFrom(
-                  primary: Colors.black,
                   side: const BorderSide(),
                 ),
                 onPressed: () async {

--- a/lib/pages/import_song_by_id.dart
+++ b/lib/pages/import_song_by_id.dart
@@ -118,7 +118,6 @@ class _ImportSongFormState extends State<ImportSongForm> {
                       ),
                     ),
                     TextFormField(
-                      cursorColor: Colors.black,
                       onChanged: _handleCopiedID,
                       // ignore: missing_return
                       validator: (value) {
@@ -132,7 +131,6 @@ class _ImportSongFormState extends State<ImportSongForm> {
                       child: OutlinedButton(
                         child: const Text('曲をインポート'),
                         style: OutlinedButton.styleFrom(
-                          primary: Colors.black,
                           side: const BorderSide(),
                         ),
                         onPressed: () {

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:my_app/models/theme_model.dart';
+import 'package:provider/provider.dart';
+
+class SettingPage extends StatelessWidget {
+  final List<DropdownMenuItem<int>> _themeList = [
+    DropdownMenuItem(
+      value: 0,
+      child: Text("自動"),
+    ),
+    DropdownMenuItem(
+      value: 1,
+      child: Text("明るい"),
+    ),
+    DropdownMenuItem(
+      value: 2,
+      child: Text("ダーク"),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text('設定'),
+      ),
+      body: SingleChildScrollView(
+          child: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Flexible(flex: 3, child: Text("アプリテーマ：　")),
+                Flexible(
+                  flex: 1,
+                  child: ButtonTheme(
+                    minWidth: 20,
+                    alignedDropdown: true,
+                    child: Consumer<ThemeModel>(builder: (_, theme, __) {
+                      return DropdownButton<int>(
+                        isExpanded: true,
+                        value: theme.themeIndex,
+                        elevation: 16,
+                        onChanged: (int newValue) {
+                          theme.themeIndex = newValue;
+                        },
+                        items: _themeList,
+                      );
+                    }),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      )),
+    );
+  }
+}

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -33,13 +33,12 @@ class SettingPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
             Row(
-              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
-                Flexible(flex: 3, child: Text("アプリテーマ：　")),
+                Flexible(flex: 1, child: Text("アプリテーマ：　")),
                 Flexible(
                   flex: 1,
                   child: ButtonTheme(
-                    minWidth: 20,
                     alignedDropdown: true,
                     child: Consumer<ThemeModel>(builder: (_, theme, __) {
                       return DropdownButton<int>(

--- a/lib/pages/songs_list.dart
+++ b/lib/pages/songs_list.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 
 import 'create_song.dart';
 import 'detail_page/tab_view.dart';
+import 'setting_page.dart';
 
 class SongsList extends StatelessWidget {
   @override
@@ -20,8 +21,12 @@ class SongsList extends StatelessWidget {
           leading: Padding(
             padding: const EdgeInsets.only(left: 8.0),
             child: IconButton(
-              icon: Icon(Icons.dark_mode),
-              onPressed: () {},
+              icon: Icon(Icons.toc),
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                    fullscreenDialog: true,
+                    builder: (context) => SettingPage()));
+              },
             ),
           ),
           actions: [],

--- a/lib/pages/songs_list.dart
+++ b/lib/pages/songs_list.dart
@@ -17,6 +17,13 @@ class SongsList extends StatelessWidget {
         appBar: AppBar(
           centerTitle: true,
           title: Text('曲一覧'),
+          leading: Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: IconButton(
+              icon: Icon(Icons.dark_mode),
+              onPressed: () {},
+            ),
+          ),
           actions: [],
         ),
         body: SongsListForm(),
@@ -37,7 +44,6 @@ class SongsList extends StatelessWidget {
                 Icons.add,
                 size: 40.0,
               ),
-              backgroundColor: Colors.green,
             )));
   }
 }


### PR DESCRIPTION

https://user-images.githubusercontent.com/81696417/131987374-38d3a8ce-cbac-408b-93a7-47e21f074c9e.mov

ダークモードに対応して、自動または任意でライト/ダークモード選択できる
設定みたいな新しいページ作ったけど、バージョン情報、みたいなのとか後々もしかしたら必要かもと思いなんとなく作った

かつそれに合わせてColors.~~ って指定したほとんどの箇所を消して、何も書かないか又はTheme.of(context).~~で書き直した
flutter がいい感じにテーマごとでやってくれるらしい
ThemeData()のPrimarySwatchを指定しないと勝手にColors.blueが適用されるらしい
ライト/ダークモードどっちも青くなってるところはPrimarySwatchを指定すればその色になるっぽい

半透明とかにもしようと思ったけどちょっと見栄え的な問題もあり一旦保留で