### PR TITLE
キーボード周りのバグなおし

### DIFF
--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -241,7 +241,7 @@ class EditingSongModel extends ChangeNotifier {
 
   void openKeyboard() {
     _keyboardIsOpening = true;
-    _keyboardBottomSpace = 300;
+    _keyboardBottomSpace = 350;
     notifyListeners();
   }
 

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -224,10 +224,13 @@ class EditingSongModel extends ChangeNotifier {
     }
   }
 
-  ///detail_edit_pageでTextFieldをTapする度に対応したTextEditingControllerを代入する
-  TextEditingController currentCodeController;
-  int controlBarIdx = 0;
-  int controlTimeIdx = 0;
+  ///detail_edit_pageでTextFieldをTapする度に対応した座標を代入する
+  int _controlBarIdx = 0;
+  get listIndex => _controlBarIdx;
+  int _controlTimeIdx = 0;
+  get idx => _controlTimeIdx;
+  TextEditingController _currentController;
+  get currentController => _currentController;
 
   bool _keyboardIsOpening = false;
   get keyboardIsOpening => _keyboardIsOpening;
@@ -260,51 +263,60 @@ class EditingSongModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void changeTextController(TextEditingController controller) {
-    this.currentCodeController = controller;
+  void changeTextController(int listIndex, int idx) {
+    _controlBarIdx = listIndex;
+    _controlTimeIdx = idx;
+    _currentController = _codeControllerList[listIndex][idx];
     notifyListeners();
   }
 
   void changeSelectionToLeft() {
-    final textSelection = currentCodeController.selection;
+    final textSelection =
+        _codeControllerList[_controlBarIdx][_controlTimeIdx].selection;
     if (textSelection.start > 0) {
-      currentCodeController.selection = TextSelection(
-          baseOffset: textSelection.start - 1,
-          extentOffset: textSelection.start - 1);
+      _codeControllerList[_controlBarIdx][_controlTimeIdx].selection =
+          TextSelection(
+              baseOffset: textSelection.start - 1,
+              extentOffset: textSelection.start - 1);
     }
   }
 
   void changeSelectionToRight() {
-    final text = currentCodeController.text;
-    final textSelection = currentCodeController.selection;
+    final text = _codeControllerList[_controlBarIdx][_controlTimeIdx].text;
+    final textSelection =
+        _codeControllerList[_controlBarIdx][_controlTimeIdx].selection;
     if (text.length > textSelection.end) {
-      currentCodeController.selection = TextSelection(
-          baseOffset: textSelection.end + 1,
-          extentOffset: textSelection.end + 1);
+      _codeControllerList[_controlBarIdx][_controlTimeIdx].selection =
+          TextSelection(
+              baseOffset: textSelection.end + 1,
+              extentOffset: textSelection.end + 1);
     }
   }
 
   void insertText(String myText) {
-    final text = currentCodeController.text;
-    final textSelection = currentCodeController.selection;
+    final text = _codeControllerList[_controlBarIdx][_controlTimeIdx].text;
+    final textSelection =
+        _codeControllerList[_controlBarIdx][_controlTimeIdx].selection;
     final newText = text.replaceRange(
       textSelection.start,
       textSelection.end,
       myText,
     );
     final myTextLength = myText.length;
-    currentCodeController.text = newText;
-    currentCodeController.selection = textSelection.copyWith(
+    _codeControllerList[_controlBarIdx][_controlTimeIdx].text = newText;
+    _codeControllerList[_controlBarIdx][_controlTimeIdx].selection =
+        textSelection.copyWith(
       baseOffset: textSelection.start + myTextLength,
       extentOffset: textSelection.start + myTextLength,
     );
-    editCodeList(newText, controlBarIdx, controlTimeIdx);
+    editCodeList(newText, _controlBarIdx, _controlTimeIdx);
     notifyListeners();
   }
 
   void backspace() {
-    final text = currentCodeController.text;
-    final textSelection = currentCodeController.selection;
+    final text = _codeControllerList[_controlBarIdx][_controlTimeIdx].text;
+    final textSelection =
+        _codeControllerList[_controlBarIdx][_controlTimeIdx].selection;
     final selectionLength = textSelection.end - textSelection.start;
 
     // There is a selection.
@@ -314,12 +326,13 @@ class EditingSongModel extends ChangeNotifier {
         textSelection.end,
         '',
       );
-      currentCodeController.text = newText;
-      currentCodeController.selection = textSelection.copyWith(
+      _codeControllerList[_controlBarIdx][_controlTimeIdx].text = newText;
+      _codeControllerList[_controlBarIdx][_controlTimeIdx].selection =
+          textSelection.copyWith(
         baseOffset: textSelection.start,
         extentOffset: textSelection.start,
       );
-      editCodeList(newText, controlBarIdx, controlTimeIdx);
+      editCodeList(newText, _controlBarIdx, _controlTimeIdx);
       notifyListeners();
     }
 
@@ -338,12 +351,13 @@ class EditingSongModel extends ChangeNotifier {
       newEnd,
       '',
     );
-    currentCodeController.text = newText;
-    currentCodeController.selection = textSelection.copyWith(
+    _codeControllerList[_controlBarIdx][_controlTimeIdx].text = newText;
+    _codeControllerList[_controlBarIdx][_controlTimeIdx].selection =
+        textSelection.copyWith(
       baseOffset: newStart,
       extentOffset: newStart,
     );
-    editCodeList(newText, controlBarIdx, controlTimeIdx);
+    editCodeList(newText, _controlBarIdx, _controlTimeIdx);
     notifyListeners();
   }
 

--- a/lib/models/editing_song.dart
+++ b/lib/models/editing_song.dart
@@ -165,7 +165,6 @@ class EditingSongModel extends ChangeNotifier {
     if (editScrollController.hasClients) {
       switch (mode) {
         case "code":
-          print(_codeFormOffsetList[listIndex]);
           editScrollController.animateTo(
             (_codeFormOffsetList[listIndex] > deviceHeight / 2)
                 ? _codeFormOffsetList[listIndex] - (deviceHeight / 2)
@@ -175,7 +174,6 @@ class EditingSongModel extends ChangeNotifier {
           );
           break;
         case "lyrics":
-          print(_lyricFormOffsetList[listIndex]);
           editScrollController.animateTo(
             (_lyricFormOffsetList[listIndex] > deviceHeight / 2)
                 ? _lyricFormOffsetList[listIndex] - (deviceHeight / 2)
@@ -206,10 +204,31 @@ class EditingSongModel extends ChangeNotifier {
     }
   }
 
+  List<TextEditingController> _lyricControllerList = [];
+  get lyricControllerList => _lyricControllerList;
+  set lyricControllerList(TextEditingController controller) {
+    if (controller == null) {
+      _lyricControllerList = [];
+    } else {
+      _lyricControllerList.add(controller);
+    }
+  }
+
+  List<List<TextEditingController>> _codeControllerList = [];
+  get codeControllerList => _codeControllerList;
+  set codeControllerList(List<TextEditingController> controllerList) {
+    if (controllerList == null) {
+      _codeControllerList = [];
+    } else {
+      _codeControllerList.add(controllerList);
+    }
+  }
+
   ///detail_edit_pageでTextFieldをTapする度に対応したTextEditingControllerを代入する
-  TextEditingController controller;
+  TextEditingController currentCodeController;
   int controlBarIdx = 0;
   int controlTimeIdx = 0;
+
   bool _keyboardIsOpening = false;
   get keyboardIsOpening => _keyboardIsOpening;
   double _keyboardBottomSpace = 0;
@@ -242,47 +261,40 @@ class EditingSongModel extends ChangeNotifier {
   }
 
   void changeTextController(TextEditingController controller) {
-    this.controller = controller;
+    this.currentCodeController = controller;
     notifyListeners();
   }
 
   void changeSelectionToLeft() {
-    final textSelection = controller.selection;
+    final textSelection = currentCodeController.selection;
     if (textSelection.start > 0) {
-      controller.selection = TextSelection(
+      currentCodeController.selection = TextSelection(
           baseOffset: textSelection.start - 1,
           extentOffset: textSelection.start - 1);
-      notifyListeners();
     }
   }
 
   void changeSelectionToRight() {
-    final text = controller.text;
-    final textSelection = controller.selection;
+    final text = currentCodeController.text;
+    final textSelection = currentCodeController.selection;
     if (text.length > textSelection.end) {
-      controller.selection = TextSelection(
+      currentCodeController.selection = TextSelection(
           baseOffset: textSelection.end + 1,
           extentOffset: textSelection.end + 1);
-      notifyListeners();
     }
   }
 
   void insertText(String myText) {
-    final text = controller.text;
-    final textSelection = controller.selection;
-    print(textSelection.start);
-    print(textSelection.end);
+    final text = currentCodeController.text;
+    final textSelection = currentCodeController.selection;
     final newText = text.replaceRange(
       textSelection.start,
       textSelection.end,
       myText,
     );
-    print(text);
-    print(textSelection.start);
-    print(textSelection.end);
     final myTextLength = myText.length;
-    controller.text = newText;
-    controller.selection = textSelection.copyWith(
+    currentCodeController.text = newText;
+    currentCodeController.selection = textSelection.copyWith(
       baseOffset: textSelection.start + myTextLength,
       extentOffset: textSelection.start + myTextLength,
     );
@@ -291,8 +303,8 @@ class EditingSongModel extends ChangeNotifier {
   }
 
   void backspace() {
-    final text = controller.text;
-    final textSelection = controller.selection;
+    final text = currentCodeController.text;
+    final textSelection = currentCodeController.selection;
     final selectionLength = textSelection.end - textSelection.start;
 
     // There is a selection.
@@ -302,8 +314,8 @@ class EditingSongModel extends ChangeNotifier {
         textSelection.end,
         '',
       );
-      controller.text = newText;
-      controller.selection = textSelection.copyWith(
+      currentCodeController.text = newText;
+      currentCodeController.selection = textSelection.copyWith(
         baseOffset: textSelection.start,
         extentOffset: textSelection.start,
       );
@@ -326,8 +338,8 @@ class EditingSongModel extends ChangeNotifier {
       newEnd,
       '',
     );
-    controller.text = newText;
-    controller.selection = textSelection.copyWith(
+    currentCodeController.text = newText;
+    currentCodeController.selection = textSelection.copyWith(
       baseOffset: newStart,
       extentOffset: newStart,
     );

--- a/lib/models/theme_model.dart
+++ b/lib/models/theme_model.dart
@@ -42,6 +42,7 @@ class ThemeModel extends ChangeNotifier {
         iconTheme: const IconThemeData(color: Colors.black)),
     //チェックボックスの色をprimaryColorに合わせる。default = primarySwatch
     toggleableActiveColor: Colors.blue[800],
+    bottomSheetTheme: BottomSheetThemeData(backgroundColor: Colors.transparent),
   );
 
   //_lightTheme.copyWith() method doesn't work
@@ -86,6 +87,7 @@ class ThemeModel extends ChangeNotifier {
       selectionColor: Colors.blue[800],
       selectionHandleColor: Colors.blue[800],
     ),
+    bottomSheetTheme: BottomSheetThemeData(backgroundColor: Colors.transparent),
   );
   get darkTheme => _darkTheme;
 

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -34,7 +34,7 @@ class CustomKeyboard extends StatelessWidget {
           insertPadding,
           buildRowThree(),
           insertPadding,
-          buildRowFour(),
+          buildRowFour(context),
           Padding(padding: EdgeInsets.only(bottom: 30))
         ],
       ),
@@ -150,12 +150,15 @@ class CustomKeyboard extends StatelessWidget {
     );
   }
 
-  Expanded buildRowFour() {
+  Expanded buildRowFour(BuildContext context) {
     return Expanded(
       child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
         FunctionKey(
           label: "abc",
           keyWidth: 4,
+          onTapped: () {
+            FocusScope.of(context).unfocus();
+          },
         ),
         TextKey(
           text: " ",
@@ -166,6 +169,12 @@ class CustomKeyboard extends StatelessWidget {
         FunctionKey(
           label: "Done",
           keyWidth: 4,
+          onTapped: () {
+            Provider.of<EditingSongModel>(context, listen: false)
+                .closeKeyboard();
+            Navigator.of(context).pop();
+            FocusScope.of(context).unfocus();
+          },
         ),
       ]),
     );
@@ -296,7 +305,10 @@ class FunctionKey extends StatelessWidget {
             borderRadius: BorderRadius.circular(5),
           ),
           child: InkWell(
-            onTap: () => onTapped,
+            onTap: () {
+              onTapped();
+              print("tapped");
+            },
             child: Container(
               child: Center(
                 child: Text(

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -97,7 +97,7 @@ class CustomKeyboard extends StatelessWidget {
   }
 
   Expanded buildRowOne() {
-    const rowTwoElem = ["1", "2", "3", "4", "5", "6", "7", "9", "♭", "♯"];
+    const rowTwoElem = ["1", "2", "3", "4", "5", "6", "7", "9"];
 
     return Expanded(
       child: Row(
@@ -112,7 +112,7 @@ class CustomKeyboard extends StatelessWidget {
   }
 
   Expanded buildRowTwo() {
-    const rowOneElem = ["C", "D", "E", "F", "G", "A", "B", "M", "m"];
+    const rowOneElem = ["C", "D", "E", "F", "G", "A", "B", "♭", "♯"];
 
     return Expanded(
       child: Row(
@@ -127,13 +127,12 @@ class CustomKeyboard extends StatelessWidget {
   }
 
   Expanded buildRowThree() {
-    const rowThreeElem = ["dim", "sus", "add", "alt", "/", "N.C."];
+    const rowThreeElem = ["M", "m", "dim", "sus", "add", "alt", "/"];
 
     return Expanded(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          SpacerWidget(),
           Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: rowThreeElem
@@ -153,12 +152,10 @@ class CustomKeyboard extends StatelessWidget {
   Expanded buildRowFour(BuildContext context) {
     return Expanded(
       child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-        FunctionKey(
-          label: "abc",
-          keyWidth: 4,
-          onTapped: () {
-            FocusScope.of(context).unfocus();
-          },
+        TextKey(
+          text: "N.C.",
+          keyWidth: 6,
+          onTextInput: _textInputHandler,
         ),
         TextKey(
           text: " ",

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -71,11 +71,11 @@ class CustomKeyboard extends StatelessWidget {
                         filled: true),
                     textAlign: TextAlign.center,
                     controller:
-                        Provider.of<EditingSongModel>(context).controller,
+                        Provider.of<EditingSongModel>(context).currentCodeController,
                     style: const TextStyle(color: Colors.white),
                     onChanged: (text) {
                       Provider.of<EditingSongModel>(context, listen: false)
-                          .controller
+                          .currentCodeController
                           .text = text;
                     }))),
         IconButton(

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -23,7 +23,7 @@ class CustomKeyboard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       height: 300,
-      color: Colors.grey[800].withOpacity(0.8),
+      color: Colors.grey[800].withOpacity(0.9),
       child: Column(
         children: [
           buildRowSetting(context),
@@ -47,7 +47,7 @@ class CustomKeyboard extends StatelessWidget {
       child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
         IconButton(
             icon: Icon(Icons.keyboard_arrow_down_outlined,
-                color: Colors.grey.withOpacity(0.8)),
+                color: Colors.grey.withOpacity(0.9)),
             onPressed: () {
               Provider.of<EditingSongModel>(context, listen: false)
                   .closeKeyboard();
@@ -193,7 +193,7 @@ class TextKey extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 3.0),
         child: Material(
-          color: Colors.grey[500].withOpacity(0.8),
+          color: Colors.grey[500].withOpacity(0.9),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),
@@ -237,7 +237,7 @@ class BackspaceKey extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(2.0),
         child: Material(
-          color: Colors.grey[600].withOpacity(0.8),
+          color: Colors.grey[600].withOpacity(0.9),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),
@@ -291,7 +291,7 @@ class FunctionKey extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(2.0),
         child: Material(
-          color: Colors.grey[600].withOpacity(0.8),
+          color: Colors.grey[600].withOpacity(0.9),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -70,12 +70,12 @@ class CustomKeyboard extends StatelessWidget {
                         fillColor: Colors.grey[600],
                         filled: true),
                     textAlign: TextAlign.center,
-                    controller:
-                        Provider.of<EditingSongModel>(context).currentCodeController,
+                    controller: Provider.of<EditingSongModel>(context)
+                        .currentController,
                     style: const TextStyle(color: Colors.white),
                     onChanged: (text) {
                       Provider.of<EditingSongModel>(context, listen: false)
-                          .currentCodeController
+                          .currentController
                           .text = text;
                     }))),
         IconButton(

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -23,7 +23,7 @@ class CustomKeyboard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       height: 300,
-      color: Colors.grey[800],
+      color: Colors.grey[800].withOpacity(0.8),
       child: Column(
         children: [
           buildRowSetting(context),
@@ -46,8 +46,8 @@ class CustomKeyboard extends StatelessWidget {
       height: 40,
       child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
         IconButton(
-            icon: const Icon(Icons.keyboard_arrow_down_outlined,
-                color: Colors.grey),
+            icon: Icon(Icons.keyboard_arrow_down_outlined,
+                color: Colors.grey.withOpacity(0.8)),
             onPressed: () {
               Provider.of<EditingSongModel>(context, listen: false)
                   .closeKeyboard();
@@ -193,7 +193,7 @@ class TextKey extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 3.0),
         child: Material(
-          color: Colors.grey[600],
+          color: Colors.grey[500].withOpacity(0.8),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),
@@ -237,7 +237,7 @@ class BackspaceKey extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(2.0),
         child: Material(
-          color: Colors.grey[700],
+          color: Colors.grey[600].withOpacity(0.8),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),
@@ -275,11 +275,13 @@ class SpacerWidget extends StatelessWidget {
 class FunctionKey extends StatelessWidget {
   final String label;
   final int keyWidth;
+  final VoidCallback onTapped;
 
   const FunctionKey({
     Key key,
     this.label = "",
     this.keyWidth = 10,
+    this.onTapped,
   }) : super(key: key);
 
   @override
@@ -289,14 +291,12 @@ class FunctionKey extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(2.0),
         child: Material(
-          color: Colors.grey[700],
+          color: Colors.grey[600].withOpacity(0.8),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),
           child: InkWell(
-            onTap: () {
-              print("Tapped");
-            },
+            onTap: () => onTapped,
             child: Container(
               child: Center(
                 child: Text(

--- a/lib/pages/detail_page/detail_bottom_bar.dart
+++ b/lib/pages/detail_page/detail_bottom_bar.dart
@@ -33,6 +33,7 @@ Material detailBottomBar(BuildContext context) {
                   onPressed: () {
                     print("Pressed: BPM");
                     showModalBottomSheet<void>(
+                      backgroundColor: Theme.of(context).canvasColor,
                       shape: const RoundedRectangleBorder(
                           borderRadius:
                               const BorderRadius.all(Radius.circular(32.0))),

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -20,8 +20,46 @@ class DetailEditPage extends StatefulWidget {
 
 class _DetailEditPageState extends State<DetailEditPage> {
   ScrollController _scrollController;
-  final List<GlobalKey> _globalLyricFormList = [];
-  final List<GlobalKey> _globalCodeFormList = [];
+  List<GlobalKey> _globalLyricFormList = [];
+  List<GlobalKey> _globalCodeFormList = [];
+
+  //should be called before re-build
+  void _setTextFieldComponents() {
+    //initialize
+    _globalLyricFormList = [];
+    _globalCodeFormList = [];
+    Provider.of<EditingSongModel>(context, listen: false).lyricControllerList =
+        null;
+    Provider.of<EditingSongModel>(context, listen: false).codeControllerList =
+        null;
+
+    //add GlobalKey
+    for (int listIndex = 0;
+        listIndex <
+            Provider.of<EditingSongModel>(context, listen: false)
+                .codeList
+                .length;
+        listIndex++) {
+      _globalLyricFormList.add(GlobalKey<FormState>());
+      _globalCodeFormList.add(GlobalKey<FormState>());
+
+      //add TextController
+      Provider.of<EditingSongModel>(context, listen: false)
+              .lyricControllerList =
+          TextEditingController(
+              text: Provider.of<EditingSongModel>(context, listen: false)
+                  .lyricsList[listIndex]);
+
+      Provider.of<EditingSongModel>(context, listen: false).codeControllerList =
+          List.generate(
+              Provider.of<EditingSongModel>(context, listen: false)
+                  .codeList[listIndex]
+                  .length,
+              (idx) => TextEditingController(
+                  text: Provider.of<EditingSongModel>(context, listen: false)
+                      .codeList[listIndex][idx]));
+    }
+  }
 
   double _getLyricLocale(int listIndex) {
     RenderBox box =
@@ -35,16 +73,13 @@ class _DetailEditPageState extends State<DetailEditPage> {
     return box.localToGlobal(Offset.zero).dy;
   }
 
-  void _resetOffsetList() {
+  //should be called after re-build
+  void _setEachOffsetList() {
     Provider.of<EditingSongModel>(context, listen: false).codeFormOffsetList =
         -1;
     Provider.of<EditingSongModel>(context, listen: false).lyricFormOffsetList =
         -1;
-  }
 
-  void _setEachOffsetList() {
-    print("set");
-    _resetOffsetList();
     switch (Provider.of<EditingSongModel>(context, listen: false).displayType) {
       case "code":
         for (int listIndex = 0;
@@ -88,10 +123,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
     _scrollController = ScrollController();
     Provider.of<EditingSongModel>(context, listen: false).editScrollController =
         _scrollController;
-    Provider.of<EditingSongModel>(context, listen: false).lyricControllerList =
-        null;
-    Provider.of<EditingSongModel>(context, listen: false).codeControllerList =
-        null;
+    _setTextFieldComponents();
     WidgetsBinding.instance.addPostFrameCallback((cb) => _setEachOffsetList());
   }
 
@@ -167,18 +199,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
           ));
         }
       }
-
-      _globalLyricFormList.add(GlobalKey<FormState>());
-      _globalCodeFormList.add(GlobalKey<FormState>());
-
-      Provider.of<EditingSongModel>(context, listen: false)
-              .lyricControllerList =
-          TextEditingController(
-              text: Provider.of<EditingSongModel>(context, listen: false)
-                  .lyricsList[listIndex]);
-      Provider.of<EditingSongModel>(context, listen: false).codeControllerList =
-          List.generate(strings.length,
-              (idx) => TextEditingController(text: strings[idx]));
 
       lyrics.add(Flexible(
           child: Padding(
@@ -614,6 +634,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                                               child: const Text('追加'),
                                               onPressed: () async {
                                                 model.addEmptyList();
+                                                _setTextFieldComponents();
                                                 await Future.delayed(Duration(
                                                     milliseconds: 200));
                                                 model.scrollToEnd();

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -123,7 +123,8 @@ class _DetailEditPageState extends State<DetailEditPage> {
         MediaQuery.of(context).size.height;
 
     void _showCustomKeyboard(context) {
-      Scaffold.of(context).showBottomSheet((BuildContext context) {
+      Scaffold.of(context)
+          .showBottomSheet((context, {backgroundColor: Colors.transparent}) {
         return CustomKeyboard(
           onTextInput: (myText) {
             Provider.of<EditingSongModel>(context, listen: false)
@@ -195,10 +196,9 @@ class _DetailEditPageState extends State<DetailEditPage> {
                     Provider.of<EditingSongModel>(context, listen: false)
                         .closeKeyboard();
                     Navigator.of(context).pop();
-                  } else {
-                    Provider.of<EditingSongModel>(context, listen: false)
-                        .openNormalKeyboard();
                   }
+                  Provider.of<EditingSongModel>(context, listen: false)
+                      .openNormalKeyboard();
                   Provider.of<EditingSongModel>(context, listen: false)
                       .scrollToTappedForm(listIndex: listIndex, mode: "lyrics");
                 },

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -179,13 +179,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
           List.generate(strings.length,
               (idx) => TextEditingController(text: strings[idx]));
 
-      Provider.of<EditingSongModel>(context, listen: false)
-              .lyricControllerList[listIndex]
-              .selection =
-          TextSelection.fromPosition(TextPosition(
-              offset: Provider.of<EditingSongModel>(context, listen: false)
-                  .lyricsList[listIndex]
-                  .length));
       lyrics.add(Flexible(
           child: Padding(
               padding: const EdgeInsets.only(left: 24.0, right: 48.0),
@@ -202,9 +195,10 @@ class _DetailEditPageState extends State<DetailEditPage> {
                     Provider.of<EditingSongModel>(context, listen: false)
                         .closeKeyboard();
                     Navigator.of(context).pop();
+                  } else {
+                    Provider.of<EditingSongModel>(context, listen: false)
+                        .openNormalKeyboard();
                   }
-                  Provider.of<EditingSongModel>(context, listen: false)
-                      .openNormalKeyboard();
                   Provider.of<EditingSongModel>(context, listen: false)
                       .scrollToTappedForm(listIndex: listIndex, mode: "lyrics");
                 },

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -462,7 +462,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
       body: Builder(
           builder: (context) => GestureDetector(
                 onTap: () => {
-                  FocusScope.of(context).unfocus(),
                   if (Provider.of<EditingSongModel>(context, listen: false)
                       .normalKeyboardIsOpen)
                     {
@@ -475,7 +474,8 @@ class _DetailEditPageState extends State<DetailEditPage> {
                       Provider.of<EditingSongModel>(context, listen: false)
                           .closeKeyboard(),
                       Navigator.of(context).pop(),
-                    }
+                    },
+                  FocusScope.of(context).unfocus(),
                 },
                 child: Container(
                     child: Scrollbar(

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -88,6 +88,10 @@ class _DetailEditPageState extends State<DetailEditPage> {
     _scrollController = ScrollController();
     Provider.of<EditingSongModel>(context, listen: false).editScrollController =
         _scrollController;
+    Provider.of<EditingSongModel>(context, listen: false).lyricControllerList =
+        null;
+    Provider.of<EditingSongModel>(context, listen: false).codeControllerList =
+        null;
     WidgetsBinding.instance.addPostFrameCallback((cb) => _setEachOffsetList());
   }
 
@@ -166,17 +170,30 @@ class _DetailEditPageState extends State<DetailEditPage> {
       _globalLyricFormList.add(GlobalKey<FormState>());
       _globalCodeFormList.add(GlobalKey<FormState>());
 
-      final _lyricsController = TextEditingController(
-          text: Provider.of<EditingSongModel>(context, listen: false)
-              .lyricsList[listIndex]);
-      _lyricsController.selection = TextSelection.fromPosition(
-          TextPosition(offset: _lyricsController.text.length));
+      Provider.of<EditingSongModel>(context, listen: false)
+              .lyricControllerList =
+          TextEditingController(
+              text: Provider.of<EditingSongModel>(context, listen: false)
+                  .lyricsList[listIndex]);
+      Provider.of<EditingSongModel>(context, listen: false).codeControllerList =
+          List.generate(strings.length,
+              (idx) => TextEditingController(text: strings[idx]));
+
+      Provider.of<EditingSongModel>(context, listen: false)
+              .lyricControllerList[listIndex]
+              .selection =
+          TextSelection.fromPosition(TextPosition(
+              offset: Provider.of<EditingSongModel>(context, listen: false)
+                  .lyricsList[listIndex]
+                  .length));
       lyrics.add(Flexible(
           child: Padding(
               padding: const EdgeInsets.only(left: 24.0, right: 48.0),
               child: TextFormField(
                 key: _globalLyricFormList[listIndex],
-                controller: _lyricsController,
+                controller:
+                    Provider.of<EditingSongModel>(context, listen: false)
+                        .lyricControllerList[listIndex],
                 showCursor: true,
                 maxLines: null,
                 onTap: () {
@@ -198,9 +215,6 @@ class _DetailEditPageState extends State<DetailEditPage> {
               ))));
 
       for (var i = 0; i < strings.length; i++) {
-        final _controller = TextEditingController(text: strings[i]);
-        _controller.selection = TextSelection.fromPosition(
-            TextPosition(offset: _controller.text.length));
         list.add(Flexible(
             child: TextField(
           key: i == 0 ? _globalCodeFormList[listIndex] : null,
@@ -219,16 +233,13 @@ class _DetailEditPageState extends State<DetailEditPage> {
                   .openKeyboard();
             }
             Provider.of<EditingSongModel>(context, listen: false)
-                .changeTextController(_controller);
-            Provider.of<EditingSongModel>(context, listen: false)
-                .controlBarIdx = listIndex;
-            Provider.of<EditingSongModel>(context, listen: false)
-                .controlTimeIdx = i;
+                .changeTextController(listIndex, i);
             Provider.of<EditingSongModel>(context, listen: false)
                 .scrollToTappedForm(listIndex: listIndex, mode: "code");
           },
           textAlign: TextAlign.center,
-          controller: _controller,
+          controller: Provider.of<EditingSongModel>(context, listen: false)
+              .codeControllerList[listIndex][i],
           onChanged: (text) {
             Provider.of<EditingSongModel>(context, listen: false)
                 .editCodeList(text, listIndex, i);

--- a/lib/pages/detail_page/scrollable_page.dart
+++ b/lib/pages/detail_page/scrollable_page.dart
@@ -235,12 +235,11 @@ class _ScrollPageState extends State<ScrollablePage> {
                       ? Colors.amberAccent
                       : Colors.transparent,
                   child: child),
-              child: TextField(
+              child: TextFormField(
                 key: i == 0 ? _globalTextFormList[listIndex] : null,
                 enabled: false,
                 textAlign: TextAlign.center,
-                controller:
-                    TextEditingController(text: codeListState[listIndex][i]),
+                initialValue: codeListState[listIndex][i],
               ),
             ),
           ));
@@ -347,7 +346,9 @@ class _ScrollPageState extends State<ScrollablePage> {
             ],
           )),
           onTapDown: (_) {
-            Provider.of<MetronomeModel>(context, listen: false).unableScroll();
+            if (Provider.of<MetronomeModel>(context, listen: false).isPlaying)
+              Provider.of<MetronomeModel>(context, listen: false)
+                  .unableScroll();
           });
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.6.1"
   audioplayers:
     dependency: "direct main"
     description:
@@ -49,7 +49,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
@@ -246,7 +246,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   nested:
     dependency: transitive
     description:
@@ -433,7 +433,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
やったこと：
TextEditingControllerをEditingSongModelにリストとして持たせる
Statefulで使う場合はちゃんと.dispose() させたほうがいいらしい、
→なんかこれやったら歌詞もコードも、テキストのカーソル合わないバグが多分直った

やること：
それやってる最中で気づいたんだけど、今編集した時・TextFieldタップした時毎回Widget treeがリビルドされてて、
widget作るfor loopの中でList.addしてるGlobalKeyとかがやばいことになってたので修正している
FocusNodeやたら負荷大きかったのもこれかもしれない