### PR TITLE
再生部分をSingletonなclassに分けた

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -325,6 +325,8 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
+  - url_launcher (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - audioplayers (from `.symlinks/plugins/audioplayers/ios`)
@@ -335,6 +337,7 @@ DEPENDENCIES:
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
+  - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 SPEC REPOS:
   trunk:
@@ -372,6 +375,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler/ios"
   qr_code_scanner:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
+  url_launcher:
+    :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
   abseil: 6c8eb7892aefa08d929b39f9bb108e5367e3228f
@@ -385,7 +390,7 @@ SPEC CHECKSUMS:
   FirebaseCore: a6dba751680d7033b9d3831e1cfc95ead0605118
   FirebaseCoreDiagnostics: cad03be1904b975f845e632f2720c3337da27faf
   FirebaseFirestore: f4f42828c6d82f6945575611c23dd343e0e7d0aa
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
   "gRPC-C++": 13d8ccef97d5c3c441b7e3c529ef28ebee86fad2
@@ -398,6 +403,7 @@ SPEC CHECKSUMS:
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
+  url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: b4168a13e918f7e6d35a0b15090a82fbb9be5856
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -325,8 +325,6 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - url_launcher (0.0.1):
-    - Flutter
 
 DEPENDENCIES:
   - audioplayers (from `.symlinks/plugins/audioplayers/ios`)
@@ -337,7 +335,6 @@ DEPENDENCIES:
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
-  - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 SPEC REPOS:
   trunk:
@@ -375,8 +372,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler/ios"
   qr_code_scanner:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
-  url_launcher:
-    :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
   abseil: 6c8eb7892aefa08d929b39f9bb108e5367e3228f
@@ -390,7 +385,7 @@ SPEC CHECKSUMS:
   FirebaseCore: a6dba751680d7033b9d3831e1cfc95ead0605118
   FirebaseCoreDiagnostics: cad03be1904b975f845e632f2720c3337da27faf
   FirebaseFirestore: f4f42828c6d82f6945575611c23dd343e0e7d0aa
-  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
   "gRPC-C++": 13d8ccef97d5c3c441b7e3c529ef28ebee86fad2
@@ -403,7 +398,6 @@ SPEC CHECKSUMS:
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: b4168a13e918f7e6d35a0b15090a82fbb9be5856
 

--- a/lib/models/metronomeAudio_play.dart
+++ b/lib/models/metronomeAudio_play.dart
@@ -5,7 +5,7 @@ class MetronomeAudioPlay {
   static AudioPlayer audioPlayer = AudioPlayer(mode: PlayerMode.LOW_LATENCY)
     ..setReleaseMode(ReleaseMode.STOP);
 
-  static AudioCache metronomePlayer = AudioCache();
+  static AudioCache metronomePlayer = AudioCache(fixedPlayer: audioPlayer);
 
   static Future<void> loadAll(List<String> metronomeSoundList) async {
     await metronomePlayer.loadAll(metronomeSoundList);

--- a/lib/models/metronomeAudio_play.dart
+++ b/lib/models/metronomeAudio_play.dart
@@ -1,0 +1,32 @@
+import 'package:audioplayers/audio_cache.dart';
+import 'package:audioplayers/audioplayers.dart';
+
+class MetronomeAudioPlay {
+  static AudioPlayer audioPlayer = AudioPlayer(mode: PlayerMode.LOW_LATENCY)
+    ..setReleaseMode(ReleaseMode.STOP);
+
+  static AudioCache metronomePlayer = AudioCache();
+
+  static Future<void> loadAll(List<String> metronomeSoundList) async {
+    await metronomePlayer.loadAll(metronomeSoundList);
+  }
+
+  static void audioPlayerHandler(AudioPlayerState value) => null;
+
+  static void play(String metronomeSound, double soundVolume) async {
+    metronomePlayer.play(metronomeSound,
+        volume: soundVolume,
+        mode: PlayerMode.LOW_LATENCY,
+        stayAwake: true,
+        isNotification: true);
+    audioPlayer.monitorNotificationStateChanges(audioPlayerHandler);
+  }
+
+  static void clearCache() {
+    metronomePlayer?.clearCache();
+  }
+
+  static void setVolume(double soundVolume) {
+    audioPlayer.setVolume(soundVolume);
+  }
+}

--- a/lib/models/metronome_model.dart
+++ b/lib/models/metronome_model.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:audioplayers/audio_cache.dart';
-import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:quiver/async.dart';
 
-void audioPlayerHandler(AudioPlayerState value) => null;
+import './metronomeAudio_play.dart';
 
 class MetronomeModel extends ChangeNotifier {
   bool _isPlaying = false;
@@ -124,12 +123,6 @@ class MetronomeModel extends ChangeNotifier {
     _bpmTapText = "TAPで計測開始";
   }
 
-  AudioPlayer _audioPlayer = AudioPlayer(mode: PlayerMode.LOW_LATENCY)
-    ..setReleaseMode(ReleaseMode.STOP);
-  AudioCache _metronomePlayer = AudioCache(
-      fixedPlayer: AudioPlayer(mode: PlayerMode.LOW_LATENCY)
-        ..setReleaseMode(ReleaseMode.STOP));
-
   String _metronomeSound = "sounds/Metronome.mp3";
   get metronomeSound => _metronomeSound;
   set metronomeSound(int selectedIndex) {
@@ -179,7 +172,7 @@ class MetronomeModel extends ChangeNotifier {
     metronomeClear();
     _isPlaying = false;
     _metronomeContainerStatus = -1;
-    _metronomePlayer?.clearCache();
+    MetronomeAudioPlay.clearCache();
     _hasScrolledDuringPlaying = false;
     _scrollOffset = 0.0;
     scrollToNowPlaying();
@@ -187,7 +180,7 @@ class MetronomeModel extends ChangeNotifier {
   }
 
   Future<void> metronomeLoad() async {
-    await _metronomePlayer.loadAll(_metronomeSoundsList);
+    await MetronomeAudioPlay.loadAll(_metronomeSoundsList);
     _isCountInPlaying = true;
     notifyListeners();
     metronomeStart();
@@ -224,14 +217,8 @@ class MetronomeModel extends ChangeNotifier {
   }
 
   void metronomeRingSound() {
-    _metronomePlayer.play(_metronomeSound,
-        volume: _soundVolume,
-        mode: PlayerMode.LOW_LATENCY,
-        stayAwake: true,
-        isNotification: true);
-
-    ///下記のコードが無いとiOSでのみエラーを吐く。
-    _audioPlayer.monitorNotificationStateChanges(audioPlayerHandler);
+    ///MetronomeAudioPlay.play(_metronomeSound, _soundVolume); <= not for now
+    SystemSound.play(SystemSoundType.click);
 
     changeMetronomeCountStatus();
     changeMetronomeContainerColor();
@@ -265,7 +252,7 @@ class MetronomeModel extends ChangeNotifier {
     } else {
       _soundVolume = 1;
     }
-    _audioPlayer.setVolume(_soundVolume);
+    MetronomeAudioPlay.setVolume(_soundVolume);
     notifyListeners();
   }
 

--- a/lib/pages/detail_page/detail_bottom_bar.dart
+++ b/lib/pages/detail_page/detail_bottom_bar.dart
@@ -82,7 +82,8 @@ Material detailBottomBar(BuildContext context) {
                         if (Provider.of<MetronomeModel>(context, listen: false)
                                 .metronomeContainerStatus ==
                             -1) {
-                          Provider.of<MetronomeModel>(context, listen: false)
+                          await Provider.of<MetronomeModel>(context,
+                                  listen: false)
                               .metronomeLoad();
                           if (Provider.of<MetronomeModel>(context,
                                       listen: false)


### PR DESCRIPTION
AudioplayerとAudiocacheの管理を別ファイルでした
Singleton（AudioCacheとかインスタンス生成するときに同一のオブジェクトが担保される的な）にするとAudioのディレイがなくなるっていう記事に縋るおもいでやったけど結論変わらなかった↓
https://stackoverflow.com/questions/59610504/flutter-audioplayers-delay

https://zenn.dev/asteroid/articles/31104fc13cd19b256381
あとはメトロノームの速度上げるとならなくなるって問題、同一のAudioCachetとAudioPlayer使ってるのかもと思って
↑の記事の後半みたいに4つくらいAudioCacheインスタンス作って1Tickごと別のPlayerで再生するとかもやってみたけど
結果ならなくなるのは回避できたけどラグがひどくてやめた

とりあえず前言った通り、一旦SystemSoundのクリック音にしています！
Singletonクラスに分ける必要は無くなったけど、普通にAudio関係で一つにまとまってみやすいのでこのままで
今までと比べたらクリック音のがめちゃくちゃ安定に鳴ってて悲しい
なんか解決策あったら藁にもすがりたい