### PR TITLE
色々バグ修正した

### DIFF
--- a/lib/models/metronome_model.dart
+++ b/lib/models/metronome_model.dart
@@ -225,7 +225,8 @@ class MetronomeModel extends ChangeNotifier {
 
   void metronomeRingSound() {
     ///MetronomeAudioPlay.play(_metronomeSound, _soundVolume); <= not for now
-    SystemSound.play(SystemSoundType.click);
+
+    if (_soundVolume != 0) SystemSound.play(SystemSoundType.click);
 
     changeMetronomeCountStatus();
     changeMetronomeContainerColor();
@@ -259,7 +260,7 @@ class MetronomeModel extends ChangeNotifier {
     } else {
       _soundVolume = 1;
     }
-    MetronomeAudioPlay.setVolume(_soundVolume);
+    //MetronomeAudioPlay.setVolume(_soundVolume);
     notifyListeners();
   }
 

--- a/lib/pages/custom_keyboard.dart
+++ b/lib/pages/custom_keyboard.dart
@@ -235,15 +235,21 @@ class TextKey extends StatelessWidget {
             child: Container(
               child: Center(
                 child: (label == "")
-                    ? Text(
-                        text,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 16),
+                    ? FittedBox(
+                        fit: BoxFit.fitWidth,
+                        child: Text(
+                          text,
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 16),
+                        ),
                       )
-                    : Text(
-                        label,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 16),
+                    : FittedBox(
+                        fit: BoxFit.fitWidth,
+                        child: Text(
+                          label,
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 16),
+                        ),
                       ),
               ),
             ),

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -15,8 +15,9 @@ class DetailEditPage extends StatefulWidget {
   final int bpm;
   final String title;
   final String docId;
+  final String artist;
 
-  DetailEditPage({this.bpm, this.title, this.docId});
+  DetailEditPage({this.bpm, this.title, this.docId, this.artist});
 
   _DetailEditPageState createState() => _DetailEditPageState();
 }
@@ -544,6 +545,7 @@ class _DetailEditPageState extends State<DetailEditPage> {
                               return Column(
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 children: <Widget>[
+                                  songNameStyle(widget.title, widget.artist),
                                   for (int idx = 0;
                                       idx < model.chordList.length;
                                       idx++)

--- a/lib/pages/detail_page/detail_edit_page.dart
+++ b/lib/pages/detail_page/detail_edit_page.dart
@@ -161,15 +161,20 @@ class _DetailEditPageState extends State<DetailEditPage> {
     void _showCustomKeyboard(context) {
       Scaffold.of(context)
           .showBottomSheet((context, {backgroundColor: Colors.transparent}) {
-        return CustomKeyboard(
-          onTextInput: (myText) {
+            return CustomKeyboard(
+              onTextInput: (myText) {
+                Provider.of<EditingSongModel>(context, listen: false)
+                    .insertText(myText);
+              },
+              onBackspace: Provider.of<EditingSongModel>(context, listen: false)
+                  .backspace,
+            );
+          })
+          .closed
+          .whenComplete(() {
             Provider.of<EditingSongModel>(context, listen: false)
-                .insertText(myText);
-          },
-          onBackspace:
-              Provider.of<EditingSongModel>(context, listen: false).backspace,
-        );
-      });
+                .closeKeyboard();
+          });
     }
 
     Widget getChordListWidgets(context, List<String> strings, int listIndex,

--- a/lib/pages/detail_page/tab_view.dart
+++ b/lib/pages/detail_page/tab_view.dart
@@ -137,6 +137,7 @@ class _TabViewState extends State<TabView> {
                                         bpm: widget.bpm,
                                         title: widget.title,
                                         docId: widget.docId,
+                                        artist: widget.artist,
                                       );
                                     },
                                   ),


### PR DESCRIPTION
1.　手動でスワイプしてキーボード閉じた時に、openKeyboard = trueになってたから .then　みたいなやつで閉じたらfalseにするようにした

2. 　DetailEditPageにも曲名/ アーティスト名表示した

3. カスタムキーボードの、特に「N.C.」「omit」はLPの画面とかでもそうなんだけど２行になっちゃってたからFittedBoxといういい感じにしてくれるWidgetで囲んだ
↓極端な例でIpod Touchでもいい感じにできた

<img width="366" alt="スクリーンショット 2021-09-17 17 13 21" src="https://user-images.githubusercontent.com/81696417/133748819-9d17d517-b858-481e-8cfb-3c693c3d0662.png">
